### PR TITLE
NAV-26 Use single location for pipenv's venv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN pip3 install uwsgi pipenv
 WORKDIR /var/www/navigator_engine
 
 ADD Pipfile.lock /var/www/navigator_engine/Pipfile.lock
+RUN mkdir .venv
 RUN pipenv sync --dev
 
 ADD uwsgi-app.ini /var/www/uwsgi/app.ini

--- a/uwsgi-app.ini
+++ b/uwsgi-app.ini
@@ -1,6 +1,6 @@
 [uwsgi]
 plugin = python3
-virtualenv = /root/.local/share/virtualenvs/navigator_engine-KyXmnesT
+virtualenv = /var/www/navigator_engine/.venv
 wsgi-file = /var/www/navigator_engine/navigator_engine/wsgi_entrypoint.py
 
 ; generally flask apps expose the 'app' callable instead of 'application'


### PR DESCRIPTION
uwsgi config points to a random venv location from /root/ directory, could we use /var/www/navigator_engine/.venv ? Pipenv automatically uses .venv directory when it finds it in the current directory