### PR TITLE
NAV-55 Add pytest to github actions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,7 +19,9 @@ jobs:
 #     needs: lint
     name: Navigator-Engine pytest
     runs-on: ubuntu-latest
-    steps: 
+    env:
+        NAVIGATOR_ENGINE_SETTINGS = navigator_engine.config.Development
+    steps:
       - name: Check out repository code
         uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -34,5 +36,3 @@ jobs:
 
       - name: Run tests
         run: pipenv run pytest
-
-

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,7 +20,7 @@ jobs:
     name: Navigator-Engine pytest
     runs-on: ubuntu-latest
     env:
-        NAVIGATOR_ENGINE_SETTINGS = navigator_engine.config.Development
+        NAVIGATOR_ENGINE_SETTINGS: navigator_engine.config.Development
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,38 @@
+name: Tests
+on: [pull_request]
+jobs:
+
+#  lint:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: actions/setup-python@v2
+#        with:
+#          python-version: '3.9'
+#      - name: Install requirements
+#        run: pip install flake8 pycodestyle
+#      - name: Check syntax
+#        run: |
+#          flake8 . --count --max-line-length=127 --show-source --statistics
+
+  test:
+#     needs: lint
+    name: Navigator-Engine pytest
+    runs-on: ubuntu-latest
+    steps: 
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - name: Prepare venv
+        run: |
+          pip install pipenv
+          pipenv sync --dev
+      - name: Load graph
+        run: pipenv run flask navigator-engine load-graph
+
+      - name: Run tests
+        run: pipenv run pytest
+
+

--- a/Pipfile
+++ b/Pipfile
@@ -21,6 +21,7 @@ pytest = "*"
 factory-boy = "*"
 pydevd-pycharm = "*"
 pytest-mock = "*"
+python-dotenv = "*"
 
 [requires]
 python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "68b5fceea7e2e9fc5593ac2bcebc4ff3bc8e7a80e7d33363636bc952711eb1e3"
+            "sha256": "df74736c1e074951e775213d1d3ab21cf1d816505df23f82bfd173347ac7dee2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -95,11 +95,11 @@
         },
         "fonttools": {
             "hashes": [
-                "sha256:a5a09dacac7dd8037957f97d0377f862b1ff862ba8d4d3f6182bc23a4b549c7a",
-                "sha256:c1021f3c994bc35d711832d13ed6bb20a79983e2f6b6d6afce13a8f88711cb1f"
+                "sha256:68071406009e7ef6a5fdcd85d95975cd6963867bb226f2b786bfffe15d1959ef",
+                "sha256:8c8f84131bf04f3b1dcf99b9763cec35c347164ab6ad006e18d2f99fcab05529"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.28.0"
+            "version": "==4.28.1"
         },
         "greenlet": {
             "hashes": [
@@ -567,6 +567,7 @@
                 "sha256:a80eb01c43fd98257ec7a49ff5cec0edba32031b5f86503f55399a48cb2c5379",
                 "sha256:cac71d5476a6f56b50459da21f6221707e0051ebd428b2137db32ef4a43bb15e",
                 "sha256:d86abd1ddf421dea5e9cebfeb4de0d205b3dc04e78249afedba9c6c3b2227ff2",
+                "sha256:dc2d1bf41294e63c7302bf499973ac0c7f73c93c01763db43055f6525234bf11",
                 "sha256:e08b81fcd9bf98740b58dc6fdd7879e33a64dcb682201c1135f7d4a75216bb05",
                 "sha256:e3efe7ef75dfe627b354ab0af0dbc918eadee97cc80ff1aabea6d3e01114ebdd",
                 "sha256:fa2dbabaaecdb502641b0b3c00dec05fb475ae48655c66da16c9ed24eda1e711"
@@ -949,6 +950,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.2"
+        },
+        "python-dotenv": {
+            "hashes": [
+                "sha256:14f8185cc8d494662683e6914addcb7e95374771e707601dfc70166946b4c4b8",
+                "sha256:bbd3da593fc49c249397cbfbcc449cf36cb02e75afc8157fcc6a81df6fb7750a"
+            ],
+            "index": "pypi",
+            "version": "==0.19.1"
         },
         "six": {
             "hashes": [


### PR DESCRIPTION
I've noticed that the dev environment is using sqlite, but testing expects pgsql db. I did change testing to sqlite too, to make the gh actions setup easier. Linter is currently commented out, as both api and engine are failing flake8 test.