### PR TITLE
Nav 69 current milestone

### DIFF
--- a/navigator_engine/common/progress_tracker.py
+++ b/navigator_engine/common/progress_tracker.py
@@ -20,9 +20,11 @@ class ProgressTracker():
 
     def report_progress(self) -> dict:
         milestones = copy.deepcopy(self.milestones)
+        current_milestone = None
         if milestones and not milestones[-1]['completed']:
             # Calculate percentage progress for current milestone
             milestones[-1]['progress'] = milestones[-1]['progress'].percentage_progress()
+            current_milestone = milestones[-1]['id']
         milestones_to_complete, milestone_list_is_complete = self.milestones_to_complete()
         for node in milestones_to_complete:
             milestones.append({
@@ -33,6 +35,7 @@ class ProgressTracker():
             })
         self.report = {
             'progress': self.percentage_progress(),
+            'currentMilestoneID': current_milestone,
             'milestoneListFullyResolved': milestone_list_is_complete,
             'milestones': milestones
         }

--- a/navigator_engine/tests/conftest.py
+++ b/navigator_engine/tests/conftest.py
@@ -17,6 +17,7 @@ def client(scope="module"):
     with app.test_client() as client:
         with app.app_context():
             db.drop_all()
+            db.session.close()
             db.create_all()
         yield client
 
@@ -29,6 +30,7 @@ def with_app_context():
     """
     with app.app_context():
         db.drop_all()
+        db.session.close()
         db.create_all()
         yield
 

--- a/navigator_engine/tests/integration_tests/test_endpoints.py
+++ b/navigator_engine/tests/integration_tests/test_endpoints.py
@@ -56,6 +56,7 @@ def test_decide_complete(client, mocker):
         'removeSkipActions': [],
         'progress': {
             'progress': 100,
+            'currentMilestoneID': None,
             'milestoneListFullyResolved': True,
             'milestones': [{'id': 12, 'title': 'ADR Data', 'progress': 100, 'completed': True}]
         }
@@ -105,6 +106,7 @@ def test_decide_incomplete(client, mocker):
             }
         },
         'progress': {
+            'currentMilestoneID': 12,
             'milestoneListFullyResolved': True,
             'progress': 33,
             'milestones': [{'completed': False, 'id': 12, 'progress': 50, 'title': 'ADR Data'}]

--- a/navigator_engine/tests/integration_tests/test_graph_processing.py
+++ b/navigator_engine/tests/integration_tests/test_graph_processing.py
@@ -91,6 +91,7 @@ def test_progress_during_milestone():
     assert progress == {
         'progress': 33,
         'milestoneListFullyResolved': True,
+        'currentMilestoneID': 12,
         'milestones': [{
             'id': 12,
             'title': 'ADR Data',
@@ -115,6 +116,7 @@ def test_progress_prior_milestone():
     assert progress == {
         'progress': 0,
         'milestoneListFullyResolved': True,
+        'currentMilestoneID': None,
         'milestones': [{
             'id': 12,
             'title': 'ADR Data',
@@ -139,6 +141,7 @@ def test_progress_after_milestone():
     assert progress == {
         'progress': 67,
         'milestoneListFullyResolved': True,
+        'currentMilestoneID': None,
         'milestones': [{
             'id': 12,
             'title': 'ADR Data',

--- a/navigator_engine/tests/pytest.ini
+++ b/navigator_engine/tests/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-filterwarnings =
-    ignore:invalid escape sequence

--- a/navigator_engine/tests/unit_tests/test_progress_tracker.py
+++ b/navigator_engine/tests/unit_tests/test_progress_tracker.py
@@ -161,3 +161,25 @@ def test_drop_action_breadcrumb(mock_tracker, simple_network):
     mock_tracker.route = [nodes[0], nodes[1]]
     ProgressTracker.drop_action_breadcrumb(mock_tracker)
     assert mock_tracker.action_breadcrumbs == [3]
+
+
+def test_report_progress(mocker, mock_tracker):
+    milestone = factories.NodeFactory(milestone=factories.MilestoneFactory())
+    milestone_tracker = mocker.Mock(spec=ProgressTracker)
+    milestone_tracker.percentage_progress.return_value = 70
+    mock_tracker.milestones = [
+        {'id': 2, 'title': 'Mock', 'completed': False, 'progress': milestone_tracker}
+    ]
+    mock_tracker.percentage_progress.return_value = 50
+    mock_tracker.milestones_to_complete.return_value = [milestone], False
+
+    result = ProgressTracker.report_progress(mock_tracker)
+    assert result == {
+        'progress': 50,
+        'currentMilestoneID': 2,
+        'milestoneListFullyResolved': False,
+        'milestones': [
+            {'id': 2, 'title': 'Mock', 'completed': False, 'progress': 70},
+            {'id': 1, 'title': 'Test Milestone', 'progress': 0, 'completed': False}
+        ]
+    }

--- a/navigator_engine/tests/util.py
+++ b/navigator_engine/tests/util.py
@@ -12,6 +12,7 @@ logger = logging.getLogger("Tests")
 def create_demo_data():
     # Clear and reset the db
     model.db.drop_all()
+    model.db.session.close()
     model.db.create_all()
 
     # Load a simple BDG

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore:.*invalid escape sequence.*


### PR DESCRIPTION
This PR adds "currentMilestoneID" into the decide response. NOTE:

- It can't be added at the action level, because actions may belong to multiple milestones.  It can only happen at the decision level.  I have therefore put it in the progress object instead of the decision object. 
- This has flagged some limitations of our current approach to progress:
  - I think we had decided that progress should always show your "current task" e.g. what "What's next" returns.  So as you step backwards through your task list, your apparent progress doesn't change because the "What's next?" task hasn't changed. I've been wondering if there is a way you could calculate progress on each step from the action breadcumbs list, but I don't think there is at the moment. PR https://github.com/fjelltopp/navigator_engine/pull/23 offers a solution to updating progress on each step.
  - Progress is currently calculated based on **your position** in the decision graph.  But users may not like this I.e. if you skip 10 steps in a row, your progress will have jumped forward significantly because your position has jumped forward significantly, but you won't have actually completed any tasks! You then get sent back 10 steps because step one turns out to be required to proceed, your progress will jump backwards significantly even though again nothing will have actually changed.

I think this issue just has to be shelved for now, to discuss later during user acceptance testing. I have ideas for how we could improve progress calculation to overcome these issues. 