### PR TITLE
Stop action

### DIFF
--- a/navigator_engine/api.py
+++ b/navigator_engine/api.py
@@ -19,7 +19,8 @@ def decide():
                 "url": "<url from estimates dataset json datadict>",
                 "authorization_header": "<optional value to be supplied as the Authorization header tag>"
             },
-            "skipActions": ["<action_id>", "<action_id>"]
+            "skipActions": ["<action_id>", "<action_id>"],
+            "stopAction": "<action_id>"
         }
     ```
     """
@@ -34,12 +35,14 @@ def decide():
     data_loader = choose_data_loader(input_data['data']['url'])
     source_data = input_data['data']
     skip_actions = input_data.get('skipActions', [])
+    stop_action = input_data.get('stopAction', [])
 
     engine = DecisionEngine(
         graph,
         source_data,
         data_loader=data_loader,
-        skip=skip_actions
+        skip=skip_actions,
+        stop=stop_action
     )
     engine.decide()
     del engine.decision['node']

--- a/navigator_engine/tests/factories.py
+++ b/navigator_engine/tests/factories.py
@@ -9,26 +9,26 @@ class ConditionalFactory(factory.Factory):
 
     title = 'Test Conditional'
     function = 'function()'
-    id = 1
+    id = factory.Sequence(lambda n: int(n))
 
 
 class ActionFactory(factory.Factory):
     class Meta:
         model = models.Action
-    id = 1
+    id = factory.Sequence(lambda n: int(n))
     title = 'Test Action'
 
 
 class NodeFactory(factory.Factory):
     class Meta:
         model = models.Node
-    id = 1
+    id = factory.Sequence(lambda n: int(n))
 
 
 class MilestoneFactory(factory.Factory):
     class Meta:
         model = models.Milestone
-    id = 1
+    id = factory.Sequence(lambda n: int(n))
     title = "Test Milestone"
     data_loader = "return_empty()"
 
@@ -36,7 +36,7 @@ class MilestoneFactory(factory.Factory):
 class GraphFactory(factory.Factory):
     class Meta:
         model = models.Graph
-    id = 1
+    id = factory.Sequence(lambda n: int(n))
     title = "Test Graph"
 
 

--- a/navigator_engine/tests/unit_tests/test_decision_engine.py
+++ b/navigator_engine/tests/unit_tests/test_decision_engine.py
@@ -47,8 +47,27 @@ def test_get_next_node(mocker, edge_type, node):
     ])
     engine = mocker.Mock(spec=DecisionEngine)
     engine.network = network
+    engine.stop_action = None
     result = DecisionEngine.get_next_node(engine, nodes[0], edge_type)
     assert result == nodes[node]
+
+
+def test_get_next_node_stop(mocker):
+    nodes = [
+        factories.NodeFactory(id=0, conditional=factories.ConditionalFactory(id=1), conditional_id=1),
+        factories.NodeFactory(id=1, action=factories.ActionFactory(id=1), action_id=1),
+        factories.NodeFactory(id=2, action=factories.ActionFactory(id=2), action_id=2)
+    ]
+    network = networkx.DiGraph()
+    network.add_edges_from([
+        (nodes[0], nodes[1], {'type': True}),
+        (nodes[0], nodes[2], {'type': False})
+    ])
+    engine = mocker.Mock(spec=DecisionEngine)
+    engine.network = network
+    engine.stop_action = 1
+    result = DecisionEngine.get_next_node(engine, nodes[0], False)
+    assert result == nodes[1]
 
 
 def test_get_next_node_raises_error(mocker):


### PR DESCRIPTION
This is POC PR showing what we would need to do in order to update the progress on every step forwards and backwards through the task breadcrumbs.

Essentially, instead of calling `/action` to get the action details of each action in action breadcrumbs, we would actually call `/decide` but use an extra param "stopAction" - thereby running the decide process and stopping the engine if/when the specified stop action is hit. This would give you full progress calculations for that action in the decision tree. 

In a future world where the engine is storing some sort of state between requests it would be possible to take the previous decision result and the desired stop action and calculate the progress much more quickly. 

Leaving this here for discussion.  We may decide just to close the PR without merging. 
