### PR TITLE
NAV-71 Add manualConfirmationRequired to the decision

### DIFF
--- a/navigator_engine/common/decision_engine.py
+++ b/navigator_engine/common/decision_engine.py
@@ -50,10 +50,18 @@ class DecisionEngine():
         if node.id in self.skip:
             return self.skip_action(node)
         self.progress.action_breadcrumbs.append(node.id)
+
+        manual_confirmation = False
+        parent_node = self.progress.entire_route[-2]
+        if getattr(parent_node, 'conditional'):
+            function = parent_node.conditional.function
+            manual_confirmation = function.startswith("check_manual_confirmation")
+
         return {
             "id": node.id,
             "content": node.action.to_dict(),
-            "node": node
+            "node": node,
+            "manualConfirmationRequired": manual_confirmation
         }
 
     def process_milestone(self, node: model.Node) -> model.Node:

--- a/navigator_engine/pluggable_logic/conditional_functions.py
+++ b/navigator_engine/pluggable_logic/conditional_functions.py
@@ -30,3 +30,9 @@ def check_not_skipped(actions: list[int], engine: DecisionEngine) -> bool:
     skipped_actions = set(actions) & set(engine.progress.skipped)
     engine.remove_skips += list(skipped_actions)
     return not bool(skipped_actions)
+
+
+@register_conditional
+def check_manual_confirmation(action_id: int, engine: DecisionEngine) -> bool:
+    # Stub
+    return True

--- a/navigator_engine/tests/integration_tests/test_endpoints.py
+++ b/navigator_engine/tests/integration_tests/test_endpoints.py
@@ -43,6 +43,7 @@ def test_decide_complete(client, mocker):
     assert response.json == {
         'decision': {
             'id': 15,
+            'manualConfirmationRequired': False,
             'content': {
                 'title': 'Complete',
                 'displayHTML': 'Action Complete',
@@ -94,6 +95,7 @@ def test_decide_incomplete(client, mocker):
         'removeSkipActions': [],
         'decision': {
             'id': 7,
+            'manualConfirmationRequired': False,
             'content': {
                 'title': 'Upload your survey data',
                 'complete': False,
@@ -150,7 +152,11 @@ def test_action(client, mocker, node_id, expected_action):
         },
         'actionID': node_id
     }))
-    assert response.json['decision'] == {'id': node_id, 'content': expected_action}
+    assert response.json['decision'] == {
+        'id': node_id,
+        'manualConfirmationRequired': False,
+        'content': expected_action
+    }
 
 
 @pytest.mark.usefixtures('with_app_context')


### PR DESCRIPTION
Adds the field manualConfirmationRequired to the decision dict. 

API docs updated in postman.