### PR TITLE
Nav 89 skip handling

### DIFF
--- a/navigator_engine/api.py
+++ b/navigator_engine/api.py
@@ -33,14 +33,14 @@ def decide():
     graph = load_graph(choose_graph(input_data['data']['url']))
     data_loader = choose_data_loader(input_data['data']['url'])
     source_data = input_data['data']
-    skip_actions = input_data.get('skipActions', [])
+    skip_requests = input_data.get('skipActions', [])
     stop_action = input_data.get('actionID')
 
     engine = DecisionEngine(
         graph,
         source_data,
         data_loader=data_loader,
-        skip=skip_actions,
+        skip_requests=skip_requests,
         stop=stop_action
     )
     engine.decide()
@@ -56,8 +56,8 @@ def decide():
     return jsonify({
         "decision": engine.decision,
         "actions": engine.progress.action_breadcrumbs,
-        "skippedActions": engine.progress.skipped,
-        "removeSkipActions": engine.remove_skips,
+        "skippedActions": engine.progress.skipped_actions,
+        "removeSkipActions": engine.remove_skip_requests,
         "progress": engine.progress.report
     })
 

--- a/navigator_engine/common/decision_engine.py
+++ b/navigator_engine/common/decision_engine.py
@@ -16,23 +16,23 @@ logger = logging.getLogger(__name__)
 class DecisionEngine():
 
     def __init__(self, graph: model.Graph, source_data: object, data_loader: str = None,
-                 stop: str = "", skip: list[str] = [], route: list[model.Node] = []) -> None:
+                 stop: str = "", skip_requests: list[str] = [], route: list[model.Node] = []) -> None:
         self.graph: model.Graph = graph
         self.network: networkx.DigGraph = self.graph.to_networkx()
         self.data: Any = source_data
-        self.skip: list[str] = skip
-        self.remove_skips: list[str] = []
+        self.skip_requests: list[str] = skip_requests
+        self.remove_skip_requests: list[str] = []
         self.progress: ProgressTracker = ProgressTracker(self.network, route=route)
         self.decision: dict[str, Any] = {}
         self.stop_action: str = stop
         if data_loader:
             self.data = self.run_pluggable_logic(data_loader, DATA_LOADERS)
 
-    def decide(self, data: object = None, skip: list[str] = None, stop=None) -> dict:
+    def decide(self, data: object = None, skip_requests: list[str] = None, stop=None) -> dict:
         if data:
             self.data = data
-        if skip:
-            self.skip = skip
+        if skip_requests:
+            self.skip_requests = skip_requests
         if stop:
             self.stop_action = stop
         self.progress.reset()
@@ -45,7 +45,7 @@ class DecisionEngine():
             "manualConfirmationRequired": manual_confirmation_required
         }
         self.progress.report_progress()
-        self.remove_skips_not_needed()
+        self.remove_skip_requests_not_needed()
         return self.decision
 
     def process_node(self, node: model.Node) -> model.Node:
@@ -65,12 +65,12 @@ class DecisionEngine():
 
     def process_action(self, node: model.Node) -> model.Node:
         not_stop_action = node.ref != self.stop_action
-        in_skip_requests = node.ref in self.skip
+        in_skip_requests = node.ref in self.skip_requests
         skippable = node.action.skippable
         if not_stop_action and in_skip_requests and skippable:
             return self.skip_action(node)
         elif in_skip_requests and not skippable:
-            self.remove_skips.append(node.ref)
+            self.remove_skip_requests.append(node.ref)
         self.progress.action_breadcrumbs.append(node.ref)
         return node
 
@@ -79,7 +79,7 @@ class DecisionEngine():
             model.load_graph(node.milestone.graph_id),
             self.data.copy(),
             data_loader=node.milestone.data_loader,
-            skip=self.skip,
+            skip_requests=self.skip_requests,
             stop=self.stop_action
         )
         milestone_result = milestone_engine.decide()
@@ -121,15 +121,15 @@ class DecisionEngine():
         previous_node = self.progress.entire_route[-2]
         for previous_node, new_node in self.network.out_edges(previous_node):
             if node != new_node:
-                self.progress.skipped.append(node.ref)
+                self.progress.skipped_actions.append(node.ref)
                 self.progress.pop_node()
                 return self.process_node(new_node)
         raise DecisionError(f"Only one outgoing edge for node: {previous_node}")
 
-    def remove_skips_not_needed(self):
-        ignored_skips = [ref for ref in self.skip if ref not in self.progress.skipped]
+    def remove_skip_requests_not_needed(self):
+        ignored_skips = [ref for ref in self.skip_requests if ref not in self.progress.skipped_actions]
         ignored_skips_in_path = [ref for ref in ignored_skips if ref in self.progress.action_breadcrumbs]
-        self.remove_skips.extend(ref for ref in ignored_skips_in_path if ref not in self.remove_skips)
+        self.remove_skip_requests.extend(ref for ref in ignored_skips_in_path if ref not in self.remove_skip_requests)
 
     def requires_manual_confirmation(self, node: model.Node) -> bool:
         manual_confirmation = False
@@ -140,12 +140,12 @@ class DecisionEngine():
         return manual_confirmation
 
 
-def engine_factory(graph, data, data_loader=None, skip=[], stop=None) -> DecisionEngine:
+def engine_factory(graph, data, data_loader=None, skip_requests=[], stop=None) -> DecisionEngine:
     # Used to mock out engine creation in tests
     return DecisionEngine(
         graph,
         data,
-        skip=skip,
+        skip_requests=skip_requests,
         data_loader=data_loader,
         stop=stop
     )

--- a/navigator_engine/common/progress_tracker.py
+++ b/navigator_engine/common/progress_tracker.py
@@ -12,14 +12,11 @@ class ProgressTracker():
         self.entire_route: list[model.Node] = route.copy()
         self.route: list[model.Node] = []
         self.milestones: list[dict] = []
-        self.skipped: list[str] = []
+        self.skipped_actions: list[str] = []
         self.action_breadcrumbs: list[str] = []
         self.complete_node: model.Node = self.get_complete_node()
         self.root_node: model.Node = self.get_root_node()
         self.report: dict = {}
-
-    def finalize(self) -> dict:
-        return self.report_progress()
 
     def report_progress(self) -> dict:
         milestones = copy.deepcopy(self.milestones)
@@ -47,12 +44,12 @@ class ProgressTracker():
     def reset(self) -> None:
         self.entire_route = self.previous_route
         self.route = []
-        self.skipped = []
+        self.skipped_actions = []
 
     def add_milestone(self, milestone_node: model.Node,
                       milestone_progress, complete: bool = False) -> None:
         self.entire_route += milestone_progress.entire_route
-        self.skipped += milestone_progress.skipped
+        self.skipped_actions += milestone_progress.skipped_actions
         self.milestones.append({
             'id': milestone_node.ref,
             'title': milestone_node.milestone.title,

--- a/navigator_engine/common/progress_tracker.py
+++ b/navigator_engine/common/progress_tracker.py
@@ -18,6 +18,9 @@ class ProgressTracker():
         self.root_node: model.Node = self.get_root_node()
         self.report: dict = {}
 
+    def finalize(self) -> dict:
+        return self.report_progress()
+
     def report_progress(self) -> dict:
         milestones = copy.deepcopy(self.milestones)
         current_milestone = None
@@ -133,12 +136,13 @@ class ProgressTracker():
         milestone_paths = []
         # Get all "milestone" paths
         for path in all_possible_paths:
-            path = path[1:]
+            path = path[1:]  # Remove the current node
+            # Remove all nodes except milestones from each path
             milestone_paths.append([node for node in path if getattr(node, 'milestone_id')])
         # The first n elements that are the same in every milestone path consitute "known" milestones
         milestones_to_complete = [x[0] for x in zip(*milestone_paths) if len(x) == x.count(x[0])]
         # If all paths are equal, we know we have the complete list of remaining milestones
         milestone_list_is_complete = False
-        if len(milestone_paths) == milestone_paths.count(milestone_paths[0]):
+        if not milestone_paths or len(milestone_paths) == milestone_paths.count(milestone_paths[0]):
             milestone_list_is_complete = True
         return milestones_to_complete, milestone_list_is_complete

--- a/navigator_engine/pluggable_logic/conditional_functions.py
+++ b/navigator_engine/pluggable_logic/conditional_functions.py
@@ -28,8 +28,8 @@ def check_dict_value(key: Hashable, value: Hashable, engine: DecisionEngine) -> 
 def check_not_skipped(actions: list[str], engine: DecisionEngine) -> bool:
     if type(actions) is not list:
         raise TypeError(f"Must specify an list of node IDs instead of {actions}")
-    skipped_actions = [action for action in actions if action in engine.progress.skipped]
-    engine.remove_skips += list(skipped_actions)
+    skipped_actions = [action for action in actions if action in engine.progress.skipped_actions]
+    engine.remove_skip_requests += list(skipped_actions)
     return not bool(skipped_actions)
 
 

--- a/navigator_engine/tests/conftest.py
+++ b/navigator_engine/tests/conftest.py
@@ -64,8 +64,8 @@ def get_mock_engine():
     engine = mock.Mock(spec=DecisionEngine)
     engine.data = {}
     engine.network = mock.Mock(spec=DiGraph)
-    engine.remove_skips = []
-    engine.skip = []
+    engine.remove_skip_requests = []
+    engine.skip_requests = []
     engine.progress = get_mock_tracker()
     engine.stop_action = None
     return engine
@@ -77,7 +77,7 @@ def get_mock_tracker():
     tracker.route = []
     tracker.entire_route = []
     tracker.previous_route = []
-    tracker.skipped = []
+    tracker.skipped_actions = []
     tracker.milestones = []
     tracker.complete_node = factories.NodeFactory()
     tracker.action_breadcrumbs = []

--- a/navigator_engine/tests/integration_tests/test_endpoints.py
+++ b/navigator_engine/tests/integration_tests/test_endpoints.py
@@ -42,7 +42,7 @@ def test_decide_complete(client, mocker):
         },
         'actions': ['tst-2-3-a', 'tst-1-4-a', 'tst-1-5-a', 'tst-1-6-a', 'tst-1-7-a', 'tst-2-4-a', 'tst-2-5-a'],
         'skippedActions': ['tst-1-6-a'],
-        'removeSkipActions': [],
+        'removeSkipActions': ['tst-1-5-a'],
         'progress': {
             'progress': 100,
             'currentMilestoneID': None,
@@ -70,7 +70,7 @@ def test_decide_incomplete(client, mocker):
     assert response.json == {
         'actions': ['tst-2-3-a', 'tst-1-4-a', 'tst-1-5-a', 'tst-1-6-a'],
         'skippedActions': [],
-        'removeSkipActions': [],
+        'removeSkipActions': ['tst-1-5-a'],
         'decision': {
             'id': 'tst-1-6-a',
             'manualConfirmationRequired': False,

--- a/navigator_engine/tests/integration_tests/test_graph_processing.py
+++ b/navigator_engine/tests/integration_tests/test_graph_processing.py
@@ -28,10 +28,10 @@ def test_graph_processing(data, expected_node_id):
 def test_with_skip_steps(data, skip_steps, expected_node_id):
     test_util.create_demo_data()
     graph = model.load_graph(1)
-    engine = DecisionEngine(graph, data, skip=skip_steps)
+    engine = DecisionEngine(graph, data, skip_requests=skip_steps)
     result = engine.decide()
     assert result['id'] == expected_node_id
-    assert engine.progress.skipped == skip_steps
+    assert engine.progress.skipped_actions == skip_steps
 
 
 @pytest.mark.parametrize("data, skip_steps", [
@@ -42,10 +42,10 @@ def test_with_skip_steps(data, skip_steps, expected_node_id):
 def test_skipping_unskippable_step_raises_error(data, skip_steps):
     test_util.create_demo_data()
     graph = model.load_graph(1)
-    engine = DecisionEngine(graph, data, skip=skip_steps)
+    engine = DecisionEngine(graph, data, skip_requests=skip_steps)
     engine.decide()
-    assert engine.remove_skips == skip_steps
-    assert engine.progress.skipped == []
+    assert engine.remove_skip_requests == skip_steps
+    assert engine.progress.skipped_actions == []
     assert engine.decision['id'] == skip_steps[0]
 
 
@@ -92,7 +92,7 @@ def test_action_breadcrumbs(data, expected_breadcrumbs):
 def test_action_breadcrumbs_with_skips(data, skip, expected_breadcrumbs):
     test_util.create_demo_data()
     graph = model.load_graph(1)
-    engine = DecisionEngine(graph, data, skip=skip)
+    engine = DecisionEngine(graph, data, skip_requests=skip)
     engine.decide()
     assert engine.progress.action_breadcrumbs == expected_breadcrumbs
 
@@ -107,9 +107,9 @@ def test_action_breadcrumbs_with_remove_skips(skip, expected_remove_skips):
     test_util.create_demo_data()
     graph = model.load_graph(1)
     data = {'1': True, '2': False, '3': False, '4': True}
-    engine = DecisionEngine(graph, data, skip=skip)
+    engine = DecisionEngine(graph, data, skip_requests=skip)
     engine.decide()
-    assert engine.remove_skips == expected_remove_skips
+    assert engine.remove_skip_requests == expected_remove_skips
 
 
 @pytest.mark.usefixtures('with_app_context')

--- a/navigator_engine/tests/unit_tests/test_conditionals.py
+++ b/navigator_engine/tests/unit_tests/test_conditionals.py
@@ -8,10 +8,10 @@ import pytest
     (['1', '2', '3'], False, ['2', '3'])
 ])
 def test_check_not_skipped(mock_engine, actions, expected, remove_skips):
-    mock_engine.progress.skipped = ['2', '3', '4']
+    mock_engine.progress.skipped_actions = ['2', '3', '4']
     result = conditionals.check_not_skipped(actions, mock_engine)
     assert result == expected
-    assert mock_engine.remove_skips == remove_skips
+    assert mock_engine.remove_skip_requests == remove_skips
 
 
 def test_check_not_skipped_raises_error(mock_engine):

--- a/navigator_engine/tests/unit_tests/test_progress_tracker.py
+++ b/navigator_engine/tests/unit_tests/test_progress_tracker.py
@@ -11,7 +11,7 @@ def test_add_milestone(mock_tracker, mocker, completed):
     mock_tracker.route = route.copy()
     mock_tracker.entire_route = route.copy()
     mock_tracker.action_breadcrumbs = [1, 2, 3]
-    mock_tracker.skipped = [2]
+    mock_tracker.skipped_actions = [2]
 
     milestone_route = [factories.NodeFactory(id=3), factories.NodeFactory(id=4)]
     milestone_node = factories.NodeFactory(id=5, milestone=factories.MilestoneFactory())
@@ -19,7 +19,7 @@ def test_add_milestone(mock_tracker, mocker, completed):
     milestone_tracker.route = milestone_route.copy()
     milestone_tracker.entire_route = milestone_route.copy()
     milestone_tracker.action_breadcrumbs = [4, 5, 6]
-    milestone_tracker.skipped = [3]
+    milestone_tracker.skipped_actions = [3]
 
     ProgressTracker.add_milestone(mock_tracker, milestone_node, milestone_tracker, complete=completed)
 
@@ -28,7 +28,7 @@ def test_add_milestone(mock_tracker, mocker, completed):
     else:
         assert mock_tracker.action_breadcrumbs == [1, 2, 3, 4, 5, 6]
     assert mock_tracker.entire_route == route + milestone_route
-    assert mock_tracker.skipped == [2, 3]
+    assert mock_tracker.skipped_actions == [2, 3]
     assert mock_tracker.milestones == [{
         'id': milestone_node.ref,
         'title': 'Test Milestone',


### PR DESCRIPTION
This PR adds action node refs to the `removeSkipActions` list when:

- The skip request is for an unskippable action (instead of throwing a DecisionError) 
- The skip request was for a completed task (inferred as skip requests that were ignored, but for actions found in the action breadcrumbs)