### PR TITLE
NAV-129 Assume empty workflow state if not found in dataset

### DIFF
--- a/navigator_engine/pluggable_logic/data_loaders.py
+++ b/navigator_engine/pluggable_logic/data_loaders.py
@@ -74,9 +74,16 @@ def load_estimates_dataset(url_key: Hashable, auth_header_key: Hashable, engine:
     auth_header = engine.data[auth_header_key]
     engine.data = {}
     data = load_json_url(dataset_url, auth_header, 'dataset', engine)
-    data = load_estimates_dataset_resource(
-        'navigator-workflow-state',
-        auth_header,
-        engine
-    )
+    try:
+        data = load_estimates_dataset_resource(
+            'navigator-workflow-state',
+            auth_header,
+            engine
+        )
+    except IOError:
+        data['navigator-workflow-state'] = {
+            'url': None,
+            'auth_header': None,
+            'data': {'completedTasks': []}
+        }
     return data


### PR DESCRIPTION
This PR allows engine users to run the Estimates 22 BDG on estimates datasets that are missing a Navigator workflow state file. 