### PR TITLE
NAV-134 Update action API endpoint response

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 ignore =
-    W605
+    W605 W503
 
 per-file-ignores =
     navigator_engine/pluggable_logic/__init__.py: F401 F403 E402

--- a/.flake8
+++ b/.flake8
@@ -1,9 +1,10 @@
 [flake8]
 ignore =
-    W605 W503
+    W503
 
 per-file-ignores =
     navigator_engine/pluggable_logic/__init__.py: F401 F403 E402
+    navigator_engine/tests/conftest.py: W605
 
 exclude =
     .git

--- a/navigator_engine/api.py
+++ b/navigator_engine/api.py
@@ -2,6 +2,7 @@ from flask import Blueprint, jsonify, request, abort
 from navigator_engine.common.decision_engine import DecisionEngine
 from navigator_engine.model import load_graph
 from navigator_engine.common import choose_graph, choose_data_loader
+from navigator_engine import model
 import json
 
 api_blueprint = Blueprint('main', __name__, url_prefix='/api/')
@@ -56,30 +57,23 @@ def decide():
     return jsonify({
         "decision": engine.decision,
         "actions": engine.progress.action_breadcrumbs,
-        "skippedActions": engine.progress.skipped_actions,
         "removeSkipActions": engine.remove_skip_requests,
         "progress": engine.progress.report
     })
 
 
-@api_blueprint.route('/action', methods=['POST'])
-def action():
+@api_blueprint.route('/action/<action_id>')
+def action(action_id):
     """
     Get the details of a specific action in the task breadcrumbs.
-
-    POST Request takes the following json input:
-    ```
-        {
-            "data": {
-                "url": "<url from estimates dataset json datadict>",
-                "authorization_header": "<optional value to be supplied as the Authorization header tag>"
-            },
-            "actionID": "<action_id>"
-        }
-    ```
     """
-    result = decide().json
-    action = result['decision']
-    action['currentMilestone'] = result['progress']['currentMilestoneID']
-    action['skipped'] = result['decision']['id'] in result['skippedActions']
-    return jsonify(action)
+
+    node = model.load_node(node_ref=action_id)
+    action = getattr(node, 'action', None)
+    if not action:
+        abort(400, f"Please specify a valid action ID. Action {action_id} not found.")
+
+    return jsonify({
+        'id': action_id,
+        'content': action.to_dict()
+    })

--- a/navigator_engine/api.py
+++ b/navigator_engine/api.py
@@ -78,4 +78,8 @@ def action():
         }
     ```
     """
-    return decide()
+    result = decide().json
+    action = result['decision']
+    action['currentMilestone'] = result['progress']['currentMilestoneID']
+    action['skipped'] = result['decision']['id'] in result['skippedActions']
+    return jsonify(action)

--- a/navigator_engine/common/decision_engine.py
+++ b/navigator_engine/common/decision_engine.py
@@ -126,7 +126,7 @@ class DecisionEngine():
         raise DecisionError(f"Only one outgoing edge for node: {previous_node}")
 
     def remove_skip_requests_not_needed(self):
-        action_breadcrumbs_ref = [a['actionID'] for a in self.progress.action_breadcrumbs]
+        action_breadcrumbs_ref = [a['id'] for a in self.progress.action_breadcrumbs]
         ignored_skips = [ref for ref in self.skip_requests if ref not in self.progress.skipped_actions]
         ignored_skips_in_path = [ref for ref in ignored_skips if ref in action_breadcrumbs_ref]
         self.remove_skip_requests.extend(ref for ref in ignored_skips_in_path if ref not in self.remove_skip_requests)

--- a/navigator_engine/common/decision_engine.py
+++ b/navigator_engine/common/decision_engine.py
@@ -37,12 +37,10 @@ class DecisionEngine():
             self.stop_action = stop
         self.progress.reset()
         next_action = self.process_node(self.progress.root_node)
-        manual_confirmation_required = self.requires_manual_confirmation(next_action)
         self.decision = {
             "id": next_action.ref,
             "content": next_action.action.to_dict(),
-            "node": next_action,
-            "manualConfirmationRequired": manual_confirmation_required
+            "node": next_action
         }
         self.progress.report_progress()
         self.remove_skip_requests_not_needed()
@@ -73,7 +71,6 @@ class DecisionEngine():
             self.progress.skipped_actions.append(node.ref)
         elif in_skip_requests and not skippable:
             self.remove_skip_requests.append(node.ref)
-        self.progress.action_breadcrumbs.append(node.ref)
         return node
 
     def process_milestone(self, node: model.Node) -> model.Node:
@@ -129,17 +126,10 @@ class DecisionEngine():
         raise DecisionError(f"Only one outgoing edge for node: {previous_node}")
 
     def remove_skip_requests_not_needed(self):
+        action_breadcrumbs_ref = [a['actionID'] for a in self.progress.action_breadcrumbs]
         ignored_skips = [ref for ref in self.skip_requests if ref not in self.progress.skipped_actions]
-        ignored_skips_in_path = [ref for ref in ignored_skips if ref in self.progress.action_breadcrumbs]
+        ignored_skips_in_path = [ref for ref in ignored_skips if ref in action_breadcrumbs_ref]
         self.remove_skip_requests.extend(ref for ref in ignored_skips_in_path if ref not in self.remove_skip_requests)
-
-    def requires_manual_confirmation(self, node: model.Node) -> bool:
-        manual_confirmation = False
-        parent_node = self.progress.entire_route[-2]
-        if getattr(parent_node, 'conditional'):
-            function = parent_node.conditional.function
-            manual_confirmation = function.startswith("check_manual_confirmation")
-        return manual_confirmation
 
 
 def engine_factory(graph, data, data_loader=None, skip_requests=[], stop=None) -> DecisionEngine:

--- a/navigator_engine/common/graph_loader.py
+++ b/navigator_engine/common/graph_loader.py
@@ -38,7 +38,7 @@ def graph_loader(graph_config_file):
     assert file_extension == '.xlsx', 'File extension of Initial Graph Config must be XLSX'
 
     xl = pd.ExcelFile(graph_config_file)
-    regex = re.compile('[\d]{2,2}-')
+    regex = re.compile(r'[\d]{2,2}-')
     graph_sheets = list(filter(lambda x: regex.match(x), xl.sheet_names))
     graphs = {}
 
@@ -92,7 +92,7 @@ def import_data(sheet_name, graphs):
     # Loop through the graph dataframe to create nodes, conditionals and actions
     for idx in graph_data.index:
         # Create a Milestone or a Conditional depending on which one the row represents
-        p = re.compile('[\d]{2,2}-')
+        p = re.compile(r'[\d]{2,2}-')
         is_milestone = p.match(graph_data.loc[idx, DATA_COLUMNS['TITLE']])
         if is_milestone:
             milestone_sheet_name = graph_data.loc[idx, DATA_COLUMNS['TITLE']]
@@ -206,7 +206,7 @@ def import_data(sheet_name, graphs):
         model.db.session.commit()
 
         false_edge_to_id = None
-        is_milestone = re.compile('[\d]{2,2}-').match(graph_data.loc[idx, DATA_COLUMNS['TITLE']])
+        is_milestone = re.compile(r'[\d]{2,2}-').match(graph_data.loc[idx, DATA_COLUMNS['TITLE']])
 
         # Add a "False" edge from conditional to the relevant action if no skip destination is given
         if graph_data.loc[:, DATA_COLUMNS['SKIP_TO']].isnull().loc[idx] and not is_milestone:

--- a/navigator_engine/common/progress_tracker.py
+++ b/navigator_engine/common/progress_tracker.py
@@ -90,7 +90,7 @@ class ProgressTracker():
                     and getattr(child_node, 'action_id')
                     and not child_node.action.complete):
                 self.action_breadcrumbs.append({
-                    'actionID': child_node.ref,
+                    'id': child_node.ref,
                     'milestoneID': None,  # Updated under self.add_milestone
                     'skipped': child_node.ref in self.skipped_actions,
                     'manualConfirmationRequired': manual_confirmation
@@ -98,7 +98,7 @@ class ProgressTracker():
 
         if getattr(current_node, 'action_id'):
             self.action_breadcrumbs.append({
-                'actionID': current_node.ref,
+                'id': current_node.ref,
                 'milestoneID': None,  # Updated under self.add_milestone
                 'skipped': False,
                 'manualConfirmationRequired': manual_confirmation

--- a/navigator_engine/common/progress_tracker.py
+++ b/navigator_engine/common/progress_tracker.py
@@ -1,4 +1,5 @@
 from navigator_engine.common import DecisionError
+from typing import Any
 import navigator_engine.model as model
 import networkx
 import copy
@@ -13,7 +14,7 @@ class ProgressTracker():
         self.route: list[model.Node] = []
         self.milestones: list[dict] = []
         self.skipped_actions: list[str] = []
-        self.action_breadcrumbs: list[str] = []
+        self.action_breadcrumbs: list[dict[str, Any]] = []
         self.complete_node: model.Node = self.get_complete_node()
         self.root_node: model.Node = self.get_root_node()
         self.report: dict = {}
@@ -56,7 +57,15 @@ class ProgressTracker():
             'progress': 100 if complete else milestone_progress,
             'completed': complete
         })
-        self.action_breadcrumbs += milestone_progress.action_breadcrumbs
+
+        def add_milestone_id(breadcrumb):
+            breadcrumb['milestoneID'] = milestone_node.ref
+            return breadcrumb
+        self.action_breadcrumbs += list(map(
+            add_milestone_id,
+            milestone_progress.action_breadcrumbs
+        ))
+
         if complete:
             # Don't include the complete action in the action_breadcrumbs
             self.action_breadcrumbs.pop()
@@ -71,18 +80,35 @@ class ProgressTracker():
             return
         parent_node = self.route[-2]
         current_node = self.route[-1]
+
+        if getattr(parent_node, 'conditional_id'):
+            function = parent_node.conditional.function
+            manual_confirmation = function.startswith("check_manual_confirmation")
+
         for parent_node, child_node in self.network.out_edges(parent_node):
-            child_node_incomplete_action = (
-                getattr(child_node, 'action_id') and not
-                child_node.action.complete
-            )
-            if (child_node != current_node and child_node_incomplete_action):
-                self.action_breadcrumbs.append(child_node.ref)
+            if (child_node != current_node
+                    and getattr(child_node, 'action_id')
+                    and not child_node.action.complete):
+                self.action_breadcrumbs.append({
+                    'actionID': child_node.ref,
+                    'milestoneID': None,  # Updated under self.add_milestone
+                    'skipped': child_node.ref in self.skipped_actions,
+                    'manualConfirmationRequired': manual_confirmation
+                })
+
+        if getattr(current_node, 'action_id'):
+            self.action_breadcrumbs.append({
+                'actionID': current_node.ref,
+                'milestoneID': None,  # Updated under self.add_milestone
+                'skipped': False,
+                'manualConfirmationRequired': manual_confirmation
+            })
 
     def pop_node(self) -> str:
         node_ref = self.entire_route[-1]
         self.entire_route = self.entire_route[:-1]
         self.route = self.route[:-1]
+        self.action_breadcrumbs = self.action_breadcrumbs[:-1]
         return node_ref
 
     def get_complete_node(self) -> model.Node:

--- a/navigator_engine/model.py
+++ b/navigator_engine/model.py
@@ -43,7 +43,7 @@ class Action(BaseModel):
             "title": self.title,
             "displayHTML": self.html,
             "skippable": self.skippable,
-            "complete": self.complete,
+            "terminus": self.complete,
             "helpURLs": [resource.to_dict() for resource in self.resources]
         }
 

--- a/navigator_engine/tests/integration_tests/test_endpoints.py
+++ b/navigator_engine/tests/integration_tests/test_endpoints.py
@@ -40,13 +40,13 @@ def test_decide_complete(client, mocker):
             }
         },
         'actions': [
-            {'actionID': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-            {'actionID': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
-            {'actionID': 'tst-1-5-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
-            {'actionID': 'tst-1-6-a', 'milestoneID': 'tst-2-1-m', 'skipped': True, 'manualConfirmationRequired': False},
-            {'actionID': 'tst-1-7-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
-            {'actionID': 'tst-2-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-            {'actionID': 'tst-2-5-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}
+            {'id': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+            {'id': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
+            {'id': 'tst-1-5-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
+            {'id': 'tst-1-6-a', 'milestoneID': 'tst-2-1-m', 'skipped': True, 'manualConfirmationRequired': False},
+            {'id': 'tst-1-7-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
+            {'id': 'tst-2-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+            {'id': 'tst-2-5-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}
         ],
         'removeSkipActions': ['tst-1-5-a'],
         'progress': {
@@ -75,10 +75,10 @@ def test_decide_incomplete(client, mocker):
     }))
     assert response.json == {
         'actions': [
-            {'actionID': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-            {'actionID': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
-            {'actionID': 'tst-1-5-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
-            {'actionID': 'tst-1-6-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False}
+            {'id': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+            {'id': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
+            {'id': 'tst-1-5-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
+            {'id': 'tst-1-6-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False}
         ],
         'removeSkipActions': ['tst-1-5-a'],
         'decision': {

--- a/navigator_engine/tests/integration_tests/test_graph_processing.py
+++ b/navigator_engine/tests/integration_tests/test_graph_processing.py
@@ -65,11 +65,21 @@ def test_graph_processing_with_milestones(data, expected_node_id):
 
 @pytest.mark.parametrize("data, expected_breadcrumbs", [
     ({'1': True, '2': True, 'data': {'1': True, '2': True, '3': False, '4': True}},
-     ['tst-2-3-a', 'tst-1-4-a', 'tst-1-5-a', 'tst-1-6-a']),
+     [{'actionID': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+      {'actionID': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
+      {'actionID': 'tst-1-5-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
+      {'actionID': 'tst-1-6-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False}]),
     ({'1': True, '2': True, 'data': {'1': False, '2': True, '3': True, '4': True}},
-     ['tst-2-3-a', 'tst-1-4-a']),
+     [{'actionID': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+      {'actionID': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False}]),
     ({'1': True, '2': True, 'data': {'1': True, '2': True, '3': True, '4': True}},
-     ['tst-2-3-a', 'tst-1-4-a', 'tst-1-5-a', 'tst-1-6-a', 'tst-1-7-a', 'tst-2-4-a', 'tst-2-5-a']),
+     [{'actionID': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+      {'actionID': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
+      {'actionID': 'tst-1-5-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
+      {'actionID': 'tst-1-6-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
+      {'actionID': 'tst-1-7-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
+      {'actionID': 'tst-2-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+      {'actionID': 'tst-2-5-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}])
 ])
 @pytest.mark.usefixtures('with_app_context')
 def test_action_breadcrumbs(data, expected_breadcrumbs):
@@ -81,12 +91,21 @@ def test_action_breadcrumbs(data, expected_breadcrumbs):
 
 
 @pytest.mark.parametrize("data, skip, expected_breadcrumbs", [
-    ({'1': True, '2': False, '3': False, '4': True},
-     ['tst-1-5-a'], ['tst-1-4-a', 'tst-1-5-a', 'tst-1-6-a']),
-    ({'1': True, '2': False, '3': False, '4': False},
-     ['tst-1-5-a', 'tst-1-6-a'], ['tst-1-4-a', 'tst-1-5-a', 'tst-1-6-a', 'tst-1-7-a']),
-    ({'1': True, '2': False, '3': False, '4': False},
-     ['tst-1-5-a', 'tst-1-6-a', 'tst-1-7-a'], ['tst-1-4-a', 'tst-1-5-a', 'tst-1-6-a', 'tst-1-7-a', 'tst-1-8-a'])
+    ({'1': True, '2': False, '3': False, '4': True}, ['tst-1-5-a'],
+     [{'actionID': 'tst-1-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+      {'actionID': 'tst-1-5-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
+      {'actionID': 'tst-1-6-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}]),
+    ({'1': True, '2': False, '3': False, '4': False}, ['tst-1-5-a', 'tst-1-6-a'],
+     [{'actionID': 'tst-1-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+      {'actionID': 'tst-1-5-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
+      {'actionID': 'tst-1-6-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
+      {'actionID': 'tst-1-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}]),
+    ({'1': True, '2': False, '3': False, '4': False}, ['tst-1-5-a', 'tst-1-6-a', 'tst-1-7-a'],
+     [{'actionID': 'tst-1-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+      {'actionID': 'tst-1-5-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
+      {'actionID': 'tst-1-6-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
+      {'actionID': 'tst-1-7-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
+      {'actionID': 'tst-1-8-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}])
 ])
 @pytest.mark.usefixtures('with_app_context')
 def test_action_breadcrumbs_with_skips(data, skip, expected_breadcrumbs):

--- a/navigator_engine/tests/integration_tests/test_graph_processing.py
+++ b/navigator_engine/tests/integration_tests/test_graph_processing.py
@@ -65,21 +65,21 @@ def test_graph_processing_with_milestones(data, expected_node_id):
 
 @pytest.mark.parametrize("data, expected_breadcrumbs", [
     ({'1': True, '2': True, 'data': {'1': True, '2': True, '3': False, '4': True}},
-     [{'actionID': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-      {'actionID': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
-      {'actionID': 'tst-1-5-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
-      {'actionID': 'tst-1-6-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False}]),
+     [{'id': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-5-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-6-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False}]),
     ({'1': True, '2': True, 'data': {'1': False, '2': True, '3': True, '4': True}},
-     [{'actionID': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-      {'actionID': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False}]),
+     [{'id': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False}]),
     ({'1': True, '2': True, 'data': {'1': True, '2': True, '3': True, '4': True}},
-     [{'actionID': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-      {'actionID': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
-      {'actionID': 'tst-1-5-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
-      {'actionID': 'tst-1-6-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
-      {'actionID': 'tst-1-7-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
-      {'actionID': 'tst-2-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-      {'actionID': 'tst-2-5-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}])
+     [{'id': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-5-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-6-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-7-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
+      {'id': 'tst-2-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+      {'id': 'tst-2-5-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}])
 ])
 @pytest.mark.usefixtures('with_app_context')
 def test_action_breadcrumbs(data, expected_breadcrumbs):
@@ -92,20 +92,20 @@ def test_action_breadcrumbs(data, expected_breadcrumbs):
 
 @pytest.mark.parametrize("data, skip, expected_breadcrumbs", [
     ({'1': True, '2': False, '3': False, '4': True}, ['tst-1-5-a'],
-     [{'actionID': 'tst-1-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-      {'actionID': 'tst-1-5-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
-      {'actionID': 'tst-1-6-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}]),
+     [{'id': 'tst-1-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-5-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-6-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}]),
     ({'1': True, '2': False, '3': False, '4': False}, ['tst-1-5-a', 'tst-1-6-a'],
-     [{'actionID': 'tst-1-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-      {'actionID': 'tst-1-5-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
-      {'actionID': 'tst-1-6-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
-      {'actionID': 'tst-1-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}]),
+     [{'id': 'tst-1-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-5-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-6-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}]),
     ({'1': True, '2': False, '3': False, '4': False}, ['tst-1-5-a', 'tst-1-6-a', 'tst-1-7-a'],
-     [{'actionID': 'tst-1-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-      {'actionID': 'tst-1-5-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
-      {'actionID': 'tst-1-6-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
-      {'actionID': 'tst-1-7-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
-      {'actionID': 'tst-1-8-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}])
+     [{'id': 'tst-1-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-5-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-6-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-7-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-8-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}])
 ])
 @pytest.mark.usefixtures('with_app_context')
 def test_action_breadcrumbs_with_skips(data, skip, expected_breadcrumbs):

--- a/navigator_engine/tests/unit_tests/test_decision_engine.py
+++ b/navigator_engine/tests/unit_tests/test_decision_engine.py
@@ -281,11 +281,11 @@ def test_remove_skip_requests_not_needed(mock_engine):
     mock_engine.progress.skipped_actions = ['1', '3']
     mock_engine.skip_requests = ['1', '2', '3', '4', '5']
     mock_engine.progress.action_breadcrumbs = [
-        {'actionID': '0'},
-        {'actionID': '1'},
-        {'actionID': '2'},
-        {'actionID': '3'},
-        {'actionID': '4'}
+        {'id': '0'},
+        {'id': '1'},
+        {'id': '2'},
+        {'id': '3'},
+        {'id': '4'}
     ]
     mock_engine.remove_skip_requests = ['0', '2']
     DecisionEngine.remove_skip_requests_not_needed(mock_engine)

--- a/navigator_engine/tests/unit_tests/test_progress_tracker.py
+++ b/navigator_engine/tests/unit_tests/test_progress_tracker.py
@@ -10,7 +10,11 @@ def test_add_milestone(mock_tracker, mocker, completed):
     route = [factories.NodeFactory(id=1), factories.NodeFactory(id=2)]
     mock_tracker.route = route.copy()
     mock_tracker.entire_route = route.copy()
-    mock_tracker.action_breadcrumbs = [{'actionID': 1}, {'actionID': 2}, {'actionID': 3}]
+    mock_tracker.action_breadcrumbs = [
+        {'actionID': 1, 'milestoneID': None},
+        {'actionID': 2, 'milestoneID': None},
+        {'actionID': 3, 'milestoneID': None}
+    ]
     mock_tracker.skipped_actions = [2]
 
     milestone_route = [factories.NodeFactory(id=3), factories.NodeFactory(id=4)]
@@ -18,24 +22,28 @@ def test_add_milestone(mock_tracker, mocker, completed):
     milestone_tracker = mocker.Mock(spec=ProgressTracker)
     milestone_tracker.route = milestone_route.copy()
     milestone_tracker.entire_route = milestone_route.copy()
-    milestone_tracker.action_breadcrumbs = [{'actionID': 4}, {'actionID': 5}, {'actionID': 6}]
+    milestone_tracker.action_breadcrumbs = [
+        {'actionID': 4, 'milestoneID': None},
+        {'actionID': 5, 'milestoneID': None},
+        {'actionID': 6, 'milestoneID': None}
+    ]
     milestone_tracker.skipped_actions = [3]
 
     ProgressTracker.add_milestone(mock_tracker, milestone_node, milestone_tracker, complete=completed)
 
     if completed:
         assert mock_tracker.action_breadcrumbs == [
-            {'actionID': 1},
-            {'actionID': 2},
-            {'actionID': 3},
+            {'actionID': 1, 'milestoneID': None},
+            {'actionID': 2, 'milestoneID': None},
+            {'actionID': 3, 'milestoneID': None},
             {'actionID': 4, 'milestoneID': milestone_node.ref},
             {'actionID': 5, 'milestoneID': milestone_node.ref},
         ]
     else:
         assert mock_tracker.action_breadcrumbs == [
-            {'actionID': 1},
-            {'actionID': 2},
-            {'actionID': 3},
+            {'actionID': 1, 'milestoneID': None},
+            {'actionID': 2, 'milestoneID': None},
+            {'actionID': 3, 'milestoneID': None},
             {'actionID': 4, 'milestoneID': milestone_node.ref},
             {'actionID': 5, 'milestoneID': milestone_node.ref},
             {'actionID': 6, 'milestoneID': milestone_node.ref}
@@ -183,7 +191,7 @@ def test_drop_action_breadcrumb(mock_tracker, simple_network, function_name, man
     mock_tracker.skipped_actions = [nodes[2].ref]
     ProgressTracker.drop_action_breadcrumb(mock_tracker)
     assert mock_tracker.action_breadcrumbs == [{
-        'actionID': nodes[2].ref,
+        'id': nodes[2].ref,
         'milestoneID': None,
         'skipped': True,
         'manualConfirmationRequired': manual

--- a/navigator_engine/tests/unit_tests/test_progress_tracker.py
+++ b/navigator_engine/tests/unit_tests/test_progress_tracker.py
@@ -163,7 +163,7 @@ def test_milestones_to_complete(mock_tracker, simple_network, route, expected_re
     assert result == (expected_milestones, expected_result[1])
 
 
-@pytest.mark.parametrize('function_name, manual',[
+@pytest.mark.parametrize('function_name, manual', [
     ('check_other_confirmation("test")', False),
     ('check_manual_confirmation("test")', True)
 ])


### PR DESCRIPTION
Renames the action 'complete' property with 'terminus'

Reworks the action endpoint to be much simpler and not running the decide process.

`currentMilestoneID`, `manualConfirmationRequired` and `skipped` are all now provided as part of action breadcrumbs

