### PR TITLE
NAV 57 Add Action List endpoint

### DIFF
--- a/navigator_engine/api.py
+++ b/navigator_engine/api.py
@@ -105,5 +105,5 @@ def action_list():
         'milestones': decide_response['progress']['milestones'],
         'progress': decide_response['progress']['progress'],
         'actionList': reached_actions,
-        'actionListFullyResolved': False
+        'fullyResolved': False
     })

--- a/navigator_engine/api.py
+++ b/navigator_engine/api.py
@@ -62,24 +62,7 @@ def decide():
     })
 
 
-@api_blueprint.route('/action/<action_id>')
-def action(action_id):
-    """
-    Get the details of a specific action in the task breadcrumbs.
-    """
-
-    node = model.load_node(node_ref=action_id)
-    action = getattr(node, 'action', None)
-    if not action:
-        abort(400, f"Please specify a valid action ID. Action {action_id} not found.")
-
-    return jsonify({
-        'id': action_id,
-        'content': action.to_dict()
-    })
-
-
-@api_blueprint.route('/actionlist', methods=['POST'])
+@api_blueprint.route('/decide/list', methods=['POST'])
 def action_list():
     """
     Get a list of actions that need to be completed.
@@ -107,4 +90,21 @@ def action_list():
         'actionList': reached_actions,
         'fullyResolved': False,
         'removeSkipActions': decide_response['removeSkipActions']
+    })
+
+
+@api_blueprint.route('/action/<action_id>')
+def action(action_id):
+    """
+    Get the details of a specific action in the task breadcrumbs.
+    """
+
+    node = model.load_node(node_ref=action_id)
+    action = getattr(node, 'action', None)
+    if not action:
+        abort(400, f"Please specify a valid action ID. Action {action_id} not found.")
+
+    return jsonify({
+        'id': action_id,
+        'content': action.to_dict()
     })

--- a/navigator_engine/api.py
+++ b/navigator_engine/api.py
@@ -77,3 +77,33 @@ def action(action_id):
         'id': action_id,
         'content': action.to_dict()
     })
+
+
+@api_blueprint.route('/actionlist', methods=['POST'])
+def action_list():
+    """
+    Get a list of actions that need to be completed.
+
+    POST Request takes the following json input:
+    ```
+        {
+            "data": {
+                "url": "<url from estimates dataset json datadict>",
+                "authorization_header": "<optional value to be supplied as the Authorization header tag>"
+            },
+            "skipActions": ["<action_id>", "<action_id>"]
+        }
+    ```
+    """
+    decide_response = decide().json
+    reached_actions = decide_response['actions']
+    for action in reached_actions:
+        action['title'] = model.load_node(node_ref=action['id']).action.title
+        action['reached'] = True
+
+    return jsonify({
+        'milestones': decide_response['progress']['milestones'],
+        'progress': decide_response['progress']['progress'],
+        'actionList': reached_actions,
+        'actionListFullyResolved': False
+    })

--- a/navigator_engine/api.py
+++ b/navigator_engine/api.py
@@ -105,5 +105,6 @@ def action_list():
         'milestones': decide_response['progress']['milestones'],
         'progress': decide_response['progress']['progress'],
         'actionList': reached_actions,
-        'fullyResolved': False
+        'fullyResolved': False,
+        'removeSkipActions': decide_response['removeSkipActions']
     })

--- a/navigator_engine/tests/integration_tests/test_endpoints.py
+++ b/navigator_engine/tests/integration_tests/test_endpoints.py
@@ -203,6 +203,7 @@ def test_action_list(client, mocker):
     assert response.json == {
         'progress': 100,
         'fullyResolved': False,
+        'removeSkipActions': ['tst-1-5-a'],
         'actionList': [{
             'id': 'tst-2-3-a',
             'manualConfirmationRequired': False,

--- a/navigator_engine/tests/integration_tests/test_endpoints.py
+++ b/navigator_engine/tests/integration_tests/test_endpoints.py
@@ -202,7 +202,7 @@ def test_action_list(client, mocker):
     }))
     assert response.json == {
         'progress': 100,
-        'actionListFullyResolved': False,
+        'fullyResolved': False,
         'actionList': [{
             'id': 'tst-2-3-a',
             'manualConfirmationRequired': False,
@@ -249,7 +249,7 @@ def test_action_list(client, mocker):
             'id': 'tst-2-5-a',
             'manualConfirmationRequired': False,
             'milestoneID': None,
-            'reached':True,
+            'reached': True,
             'skipped': False,
             'title': 'Complete'
         }],

--- a/navigator_engine/tests/integration_tests/test_endpoints.py
+++ b/navigator_engine/tests/integration_tests/test_endpoints.py
@@ -183,3 +183,80 @@ def setup_endpoint_test(mocker, data=None):
         return_value=f'load_dict_from_json({json.dumps(json.dumps(data))})'
     )
     test_util.create_demo_data()
+
+
+@pytest.mark.usefixtures('with_app_context')
+def test_action_list(client, mocker):
+    data = {
+        '1': True,
+        '2': True,
+        'data': {'1': True, '2': True, '3': False, '4': True}
+    }
+    setup_endpoint_test(mocker, data)
+    response = client.post("/api/actionlist", data=json.dumps({
+        'data': {
+            'url': 'https://example.ckan/api/3/action/package_show?id=example',
+            'authorization_header': "example-api-key"
+        },
+        'skipActions': ['tst-1-5-a', 'tst-1-6-a']
+    }))
+    assert response.json == {
+        'progress': 100,
+        'actionListFullyResolved': False,
+        'actionList': [{
+            'id': 'tst-2-3-a',
+            'manualConfirmationRequired': False,
+            'milestoneID': None,
+            'reached': True,
+            'skipped': False,
+            'title': 'Action 1'
+        }, {
+            'id': 'tst-1-4-a',
+            'manualConfirmationRequired': False,
+            'milestoneID': 'tst-2-1-m',
+            'reached': True,
+            'skipped': False,
+            'title': 'Upload your geographic data'
+        }, {
+            'id': 'tst-1-5-a',
+            'manualConfirmationRequired': False,
+            'milestoneID': 'tst-2-1-m',
+            'reached': True,
+            'skipped': False,
+            'title': 'Validate your geographic data'
+        }, {
+            'id': 'tst-1-6-a',
+            'manualConfirmationRequired': False,
+            'milestoneID': 'tst-2-1-m',
+            'reached': True,
+            'skipped': True,
+            'title': 'Upload your survey data'
+        }, {
+            'id': 'tst-1-7-a',
+            'manualConfirmationRequired': False,
+            'milestoneID': 'tst-2-1-m',
+            'reached': True,
+            'skipped': False,
+            'title': 'Validate your survey data'
+        }, {
+            'id': 'tst-2-4-a',
+            'manualConfirmationRequired': False,
+            'milestoneID': None,
+            'reached': True,
+            'skipped': False,
+            'title': 'Action 2'
+        }, {
+            'id': 'tst-2-5-a',
+            'manualConfirmationRequired': False,
+            'milestoneID': None,
+            'reached':True,
+            'skipped': False,
+            'title': 'Complete'
+        }],
+        'milestones': [{
+            'completed': True,
+            'id': 'tst-2-1-m',
+            'progress': 100,
+            'title': 'ADR Data'
+        }],
+    }


### PR DESCRIPTION
This continues the work begun in https://github.com/fjelltopp/navigator_engine/pull/51

Adds an action list endpoint.  At the moment the endpoint only returns actions skipped or completed for as far as you have reached into the decision graph. 

I've added in `removeSkipActions` since we are calculating them and it may be that someone just sits on the action checklist hitting refresh each time they make some changes.  Hopefully that is easy to handle on the API side?