### PR TITLE
NAV-179 Completion failure

### DIFF
--- a/navigator_engine/common/progress_tracker.py
+++ b/navigator_engine/common/progress_tracker.py
@@ -81,6 +81,7 @@ class ProgressTracker():
         parent_node = self.route[-2]
         current_node = self.route[-1]
 
+        manual_confirmation = False
         if getattr(parent_node, 'conditional_id'):
             function = parent_node.conditional.function
             manual_confirmation = function.startswith("check_manual_confirmation")

--- a/navigator_engine/tests/unit_tests/test_progress_tracker.py
+++ b/navigator_engine/tests/unit_tests/test_progress_tracker.py
@@ -199,7 +199,7 @@ def test_drop_action_breadcrumb(mock_tracker, function_name, manual):
 
 
 def test_drop_action_breadcrumb_after_milestone(mock_tracker):
-    # The terminus node maybe an action node immediately following a milestone
+    # The terminus node may be an action node immediately following a milestone
     # This regression test checks that the node is properly added to the breadcrumbs
     nodes = [
         factories.NodeFactory(id=1, milestone=factories.MilestoneFactory()),


### PR DESCRIPTION
Fixes NAV-179, which is caused by a milestone immediately proceeding the terminus node in the BDG. 

It flagged a bug with the drop action breadcrumb function where I wasn't defining the manual_confirmation variable in some cases. 

Regression test included.