### PR TITLE
NAV-189 Debug skip logic

### DIFF
--- a/navigator_engine/common/decision_engine.py
+++ b/navigator_engine/common/decision_engine.py
@@ -30,11 +30,11 @@ class DecisionEngine():
             self.data = self.run_pluggable_logic(data_loader, DATA_LOADERS)
 
     def decide(self, data: object = None, skip_requests: list[str] = None, stop=None) -> dict:
-        if data:
+        if data is not None:
             self.data = data
-        if skip_requests:
+        if skip_requests is not None:
             self.skip_requests = skip_requests
-        if stop:
+        if stop is not None:
             self.stop_action = stop
         self.progress.reset()
         next_action = self.process_node(self.progress.root_node)

--- a/navigator_engine/common/decision_engine.py
+++ b/navigator_engine/common/decision_engine.py
@@ -16,13 +16,14 @@ logger = logging.getLogger(__name__)
 class DecisionEngine():
 
     def __init__(self, graph: model.Graph, source_data: object, data_loader: str = None,
-                 stop: str = "", skip_requests: list[str] = [], route: list[model.Node] = []) -> None:
+                 stop: str = "", skip_requests: list[str] = [], route: list[model.Node] = [],
+                 skipped_actions: list[str] = []) -> None:
         self.graph: model.Graph = graph
         self.network: networkx.DigGraph = self.graph.to_networkx()
         self.data: Any = source_data
         self.skip_requests: list[str] = skip_requests
         self.remove_skip_requests: list[str] = []
-        self.progress: ProgressTracker = ProgressTracker(self.network, route=route)
+        self.progress: ProgressTracker = ProgressTracker(self.network, route=route, skipped_actions=skipped_actions)
         self.decision: dict[str, Any] = {}
         self.stop_action: str = stop
         if data_loader:
@@ -79,9 +80,11 @@ class DecisionEngine():
             self.data.copy(),
             data_loader=node.milestone.data_loader,
             skip_requests=self.skip_requests,
+            skipped_actions=self.progress.skipped_actions,
             stop=self.stop_action
         )
         milestone_result = milestone_engine.decide()
+        self.remove_skip_requests += milestone_engine.remove_skip_requests
         if milestone_result['node'].action.complete:
             self.progress.add_milestone(node, milestone_engine.progress, complete=True)
             next_node = self.get_next_node(node, True)
@@ -102,7 +105,7 @@ class DecisionEngine():
         return new_node
 
     def run_pluggable_logic(self, function_string: str,
-                            functions: dict[str, Callable] = CONDITIONAL_FUNCTIONS):
+                            functions: dict[str, Callable] = CONDITIONAL_FUNCTIONS) -> Any:
         function_name, function_args = get_pluggable_function_and_args(function_string)
         try:
             function = functions[function_name]
@@ -125,19 +128,21 @@ class DecisionEngine():
                 return self.process_node(new_node)
         raise DecisionError(f"Only one outgoing edge for node: {previous_node}")
 
-    def remove_skip_requests_not_needed(self):
+    def remove_skip_requests_not_needed(self) -> None:
         action_breadcrumbs_ref = [a['id'] for a in self.progress.action_breadcrumbs]
         ignored_skips = [ref for ref in self.skip_requests if ref not in self.progress.skipped_actions]
         ignored_skips_in_path = [ref for ref in ignored_skips if ref in action_breadcrumbs_ref]
         self.remove_skip_requests.extend(ref for ref in ignored_skips_in_path if ref not in self.remove_skip_requests)
 
 
-def engine_factory(graph, data, data_loader=None, skip_requests=[], stop=None) -> DecisionEngine:
+def engine_factory(graph, data, data_loader=None, skip_requests=[],
+                   stop=None, skipped_actions=[]) -> DecisionEngine:
     # Used to mock out engine creation in tests
     return DecisionEngine(
         graph,
         data,
         skip_requests=skip_requests,
         data_loader=data_loader,
-        stop=stop
+        stop=stop,
+        skipped_actions=skipped_actions
     )

--- a/navigator_engine/common/graph_loader.py
+++ b/navigator_engine/common/graph_loader.py
@@ -312,12 +312,13 @@ def _create_check_skips_action(conditional, graph_data):
         tasks.append(node.action.title)
     tasks_list = "\n - ".join(tasks)
 
-    graph_data[DATA_COLUMNS['ACTION']] = "You have skipped some essential tasks"
+    graph_data[DATA_COLUMNS['ACTION']] = "You must complete some previous tasks"
     graph_data[DATA_COLUMNS['ACTION_CONTENT']] = (
-        f"You have skipped some of following essential tasks:\n\n - {tasks_list}\n\n"
+        f"One or more of the following essential tasks remains incomplete:\n\n - {tasks_list}\n\n"
         "You must ensure you complete all these tasks in order to proceed any further.\n\n"
+        "Navigator will now take you back to ensure you complete these tasks.\n\n"
         "If you have understood this message, mark this task as complete and click *What's"
-        "Next* to be taken to the first of your incomplete essential tasks."
+        "Next?* to see the first of your essential incomplete tasks."
     )
 
     return graph_data

--- a/navigator_engine/common/progress_tracker.py
+++ b/navigator_engine/common/progress_tracker.py
@@ -7,13 +7,15 @@ import copy
 
 class ProgressTracker():
 
-    def __init__(self, network: networkx.DiGraph, route: list[model.Node] = []) -> None:
+    def __init__(self, network: networkx.DiGraph,
+                 route: list[model.Node] = [], skipped_actions: list[str] = []) -> None:
         self.network: networkx.DiGraph = network
         self.previous_route: list[model.Node] = route.copy()
         self.entire_route: list[model.Node] = route.copy()
         self.route: list[model.Node] = []
         self.milestones: list[dict] = []
-        self.skipped_actions: list[str] = []
+        self.previously_skipped_actions: list[str] = skipped_actions.copy()
+        self.skipped_actions: list[str] = skipped_actions.copy()
         self.action_breadcrumbs: list[dict[str, Any]] = []
         self.complete_node: model.Node = self.get_complete_node()
         self.root_node: model.Node = self.get_root_node()
@@ -45,12 +47,12 @@ class ProgressTracker():
     def reset(self) -> None:
         self.entire_route = self.previous_route
         self.route = []
-        self.skipped_actions = []
+        self.skipped_actions = self.previously_skipped_actions
 
     def add_milestone(self, milestone_node: model.Node,
                       milestone_progress, complete: bool = False) -> None:
-        self.entire_route += milestone_progress.entire_route
-        self.skipped_actions += milestone_progress.skipped_actions
+        self.entire_route = milestone_progress.entire_route
+        self.skipped_actions = milestone_progress.skipped_actions
         self.milestones.append({
             'id': milestone_node.ref,
             'title': milestone_node.milestone.title,

--- a/navigator_engine/tests/conftest.py
+++ b/navigator_engine/tests/conftest.py
@@ -78,6 +78,7 @@ def get_mock_tracker():
     tracker.entire_route = []
     tracker.previous_route = []
     tracker.skipped_actions = []
+    tracker.previously_skipped_actions = []
     tracker.milestones = []
     tracker.complete_node = factories.NodeFactory()
     tracker.action_breadcrumbs = []

--- a/navigator_engine/tests/integration_tests/test_endpoints.py
+++ b/navigator_engine/tests/integration_tests/test_endpoints.py
@@ -254,7 +254,7 @@ def test_action_list(client, mocker):
             'milestoneID': 'tst-2-6-m',
             'reached': True,
             'skipped': False,
-            'title': 'Action 1'
+            'title': 'Naomi Action 1'
         }, {
             'id': 'tst-2-4-a',
             'manualConfirmationRequired': False,

--- a/navigator_engine/tests/integration_tests/test_endpoints.py
+++ b/navigator_engine/tests/integration_tests/test_endpoints.py
@@ -18,7 +18,8 @@ def test_decide_complete(client, mocker):
     data = {
         '1': True,
         '2': True,
-        'data': {'1': True, '2': True, '3': False, '4': True}
+        'data': {'1': True, '2': True, '3': False, '4': True},
+        'naomi': {'1': True}
     }
     setup_endpoint_test(mocker, data)
     response = client.post("/api/decide", data=json.dumps({
@@ -33,7 +34,7 @@ def test_decide_complete(client, mocker):
             'id': 'tst-2-5-a',
             'content': {
                 'title': 'Complete',
-                'displayHTML': 'Action Complete',
+                'displayHTML': 'Milestone Complete',
                 'skippable': False,
                 'terminus': True,
                 'helpURLs': []
@@ -45,6 +46,7 @@ def test_decide_complete(client, mocker):
             {'id': 'tst-1-5-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
             {'id': 'tst-1-6-a', 'milestoneID': 'tst-2-1-m', 'skipped': True, 'manualConfirmationRequired': False},
             {'id': 'tst-1-7-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
+            {'id': 'tst-3-1-a', 'milestoneID': 'tst-2-6-m', 'skipped': False, 'manualConfirmationRequired': False},
             {'id': 'tst-2-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
             {'id': 'tst-2-5-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}
         ],
@@ -53,7 +55,10 @@ def test_decide_complete(client, mocker):
             'progress': 100,
             'currentMilestoneID': None,
             'milestoneListFullyResolved': True,
-            'milestones': [{'id': 'tst-2-1-m', 'title': 'ADR Data', 'progress': 100, 'completed': True}]
+            'milestones': [
+                {'id': 'tst-2-1-m', 'title': 'ADR Data', 'progress': 100, 'completed': True},
+                {'id': 'tst-2-6-m', 'title': 'Naomi Data Review', 'progress': 100, 'completed': True}
+            ]
         }
     }
 
@@ -97,8 +102,11 @@ def test_decide_incomplete(client, mocker):
         'progress': {
             'currentMilestoneID': 'tst-2-1-m',
             'milestoneListFullyResolved': True,
-            'progress': 33,
-            'milestones': [{'completed': False, 'id': 'tst-2-1-m', 'progress': 50, 'title': 'ADR Data'}]
+            'progress': 25,
+            'milestones': [
+                {'id': 'tst-2-1-m', 'title': 'ADR Data', 'progress': 50, 'completed': False},
+                {'id': 'tst-2-6-m', 'title': 'Naomi Data Review', 'progress': 0, 'completed': False}
+            ]
         }
     }
 
@@ -144,7 +152,7 @@ def test_decide_without_url_raises_bad_request(client, mocker):
     ('tst-2-5-a', {
         'id': 'tst-2-5-a',
         'content': {
-            'displayHTML': 'Action Complete',
+            'displayHTML': 'Milestone Complete',
             'helpURLs': [],
             'skippable': False,
             'terminus': True,
@@ -190,7 +198,8 @@ def test_action_list(client, mocker):
     data = {
         '1': True,
         '2': True,
-        'data': {'1': True, '2': True, '3': False, '4': True}
+        'data': {'1': True, '2': True, '3': False, '4': True},
+        'naomi': {'1': True}
     }
     setup_endpoint_test(mocker, data)
     response = client.post("/api/decide/list", data=json.dumps({
@@ -240,6 +249,13 @@ def test_action_list(client, mocker):
             'skipped': False,
             'title': 'Validate your survey data'
         }, {
+            'id': 'tst-3-1-a',
+            'manualConfirmationRequired': False,
+            'milestoneID': 'tst-2-6-m',
+            'reached': True,
+            'skipped': False,
+            'title': 'Action 1'
+        }, {
             'id': 'tst-2-4-a',
             'manualConfirmationRequired': False,
             'milestoneID': None,
@@ -259,5 +275,10 @@ def test_action_list(client, mocker):
             'id': 'tst-2-1-m',
             'progress': 100,
             'title': 'ADR Data'
+        }, {
+            'completed': True,
+            'id': 'tst-2-6-m',
+            'progress': 100,
+            'title': 'Naomi Data Review'
         }],
     }

--- a/navigator_engine/tests/integration_tests/test_graph_processing.py
+++ b/navigator_engine/tests/integration_tests/test_graph_processing.py
@@ -221,3 +221,23 @@ def test_progress_after_milestone():
             'title': 'Naomi Data Review'
         }]
     }
+
+
+@pytest.mark.usefixtures('with_app_context')
+def test_skip_check_logic():
+    test_util.create_demo_data()
+    node = model.load_node(node_ref='tst-3-0-c')
+    node.conditional.function = "check_not_skipped(['tst-1-5-a'])"
+    model.db.session.add(node)
+    model.db.session.commit()
+    graph = model.load_graph(2)
+    data = {
+        '1': True,
+        '2': True,
+        'data': {'1': True, '2': False, '3': True, '4': True},
+        'naomi': {}
+    }
+    engine = DecisionEngine(graph, data, skip_requests=['tst-1-5-a'])
+    engine.decide()
+    assert engine.decision['id'] == 'tst-3-1-a'
+    assert engine.remove_skip_requests == ['tst-1-5-a']

--- a/navigator_engine/tests/integration_tests/test_graph_processing.py
+++ b/navigator_engine/tests/integration_tests/test_graph_processing.py
@@ -50,9 +50,9 @@ def test_skipping_unskippable_step_raises_error(data, skip_steps):
 
 
 @pytest.mark.parametrize("data, expected_node_id", [
-    ({'1': True, '2': True, 'data': {'1': True, '2': True, '3': False, '4': True}}, 'tst-1-6-a'),
-    ({'1': True, '2': True, 'data': {'1': False, '2': True, '3': True, '4': True}}, 'tst-1-4-a'),
-    ({'1': True, '2': True, 'data': {'1': True, '2': True, '3': True, '4': True}}, 'tst-2-5-a')
+    ({'1': True, '2': True, 'data': {'1': True, '2': True, '3': False, '4': True}, 'naomi': {'1': True}}, 'tst-1-6-a'),
+    ({'1': True, '2': True, 'data': {'1': False, '2': True, '3': True, '4': True}, 'naomi': {'1': True}}, 'tst-1-4-a'),
+    ({'1': True, '2': True, 'data': {'1': True, '2': True, '3': True, '4': True}, 'naomi': {'1': True}}, 'tst-2-5-a')
 ])
 @pytest.mark.usefixtures('with_app_context')
 def test_graph_processing_with_milestones(data, expected_node_id):
@@ -64,20 +64,21 @@ def test_graph_processing_with_milestones(data, expected_node_id):
 
 
 @pytest.mark.parametrize("data, expected_breadcrumbs", [
-    ({'1': True, '2': True, 'data': {'1': True, '2': True, '3': False, '4': True}},
+    ({'1': True, '2': True, 'data': {'1': True, '2': True, '3': False, '4': True}, 'naomi': {'1': True}},
      [{'id': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
       {'id': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
       {'id': 'tst-1-5-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
       {'id': 'tst-1-6-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False}]),
-    ({'1': True, '2': True, 'data': {'1': False, '2': True, '3': True, '4': True}},
+    ({'1': True, '2': True, 'data': {'1': False, '2': True, '3': True, '4': True}, 'naomi': {'1': True}},
      [{'id': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
       {'id': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False}]),
-    ({'1': True, '2': True, 'data': {'1': True, '2': True, '3': True, '4': True}},
+    ({'1': True, '2': True, 'data': {'1': True, '2': True, '3': True, '4': True}, 'naomi': {'1': True}},
      [{'id': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
       {'id': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
       {'id': 'tst-1-5-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
       {'id': 'tst-1-6-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
       {'id': 'tst-1-7-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
+      {'id': 'tst-3-1-a', 'milestoneID': 'tst-2-6-m', 'skipped': False, 'manualConfirmationRequired': False},
       {'id': 'tst-2-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
       {'id': 'tst-2-5-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}])
 ])
@@ -144,7 +145,7 @@ def test_progress_during_milestone():
     engine.decide()
     progress = engine.progress.report_progress()
     assert progress == {
-        'progress': 33,
+        'progress': 25,
         'milestoneListFullyResolved': True,
         'currentMilestoneID': 'tst-2-1-m',
         'milestones': [{
@@ -152,6 +153,11 @@ def test_progress_during_milestone():
             'title': 'ADR Data',
             'progress': 50,
             'completed': False
+        }, {
+            'completed': False,
+            'id': 'tst-2-6-m',
+            'progress': 0,
+            'title': 'Naomi Data Review'
         }]
     }
 
@@ -177,6 +183,11 @@ def test_progress_prior_milestone():
             'title': 'ADR Data',
             'progress': 0,
             'completed': False
+        }, {
+            'completed': False,
+            'id': 'tst-2-6-m',
+            'progress': 0,
+            'title': 'Naomi Data Review'
         }]
     }
 
@@ -188,13 +199,14 @@ def test_progress_after_milestone():
     data = {
         '1': True,
         '2': False,
-        'data': {'1': True, '2': True, '3': True, '4': True}
+        'data': {'1': True, '2': True, '3': True, '4': True},
+        'naomi': {'1': True}
     }
     engine = DecisionEngine(graph, data)
     engine.decide()
     progress = engine.progress.report_progress()
     assert progress == {
-        'progress': 67,
+        'progress': 75,
         'milestoneListFullyResolved': True,
         'currentMilestoneID': None,
         'milestones': [{
@@ -202,5 +214,10 @@ def test_progress_after_milestone():
             'title': 'ADR Data',
             'progress': 100,
             'completed': True
+        }, {
+            'completed': True,
+            'id': 'tst-2-6-m',
+            'progress': 100,
+            'title': 'Naomi Data Review'
         }]
     }

--- a/navigator_engine/tests/unit_tests/test_decision_engine.py
+++ b/navigator_engine/tests/unit_tests/test_decision_engine.py
@@ -147,9 +147,11 @@ def test_process_milestone_incomplete(mocker, mock_engine):
 
     mock_engine.run_pluggable_logic.return_value = True
     mock_engine.process_action.return_value = "processed_action"
+    mock_engine.remove_skip_requests = [2]
     mocker.patch('navigator_engine.model.load_graph', return_value=milestone_graph)
 
     milestone_engine = mocker.Mock(spec=DecisionEngine)
+    milestone_engine.remove_skip_requests = [3]
     milestone_engine.progress = mocker.patch(
         'navigator_engine.common.progress_tracker.ProgressTracker',
         auto_spec=True
@@ -164,6 +166,7 @@ def test_process_milestone_incomplete(mocker, mock_engine):
     result = DecisionEngine.process_milestone(mock_engine, node1)
     mock_engine.progress.add_milestone.assert_called_once_with(node1, milestone_engine.progress)
     assert result == node2
+    assert mock_engine.remove_skip_requests == [2, 3]
 
 
 def test_process_milestone_complete(mocker, mock_engine):
@@ -178,9 +181,11 @@ def test_process_milestone_complete(mocker, mock_engine):
     mock_engine.run_pluggable_logic.return_value = {}
     mock_engine.get_next_node.return_value = node3
     mock_engine.process_node.return_value = "processed_action"
+    mock_engine.remove_skip_requests = [2]
     mocker.patch('navigator_engine.model.load_graph')
 
     milestone_engine = mocker.Mock(spec=DecisionEngine)
+    milestone_engine.remove_skip_requests = [3]
     milestone_engine.progress = mocker.patch(
         'navigator_engine.common.progress_tracker.ProgressTracker',
         auto_spec=True
@@ -194,6 +199,7 @@ def test_process_milestone_complete(mocker, mock_engine):
     result = DecisionEngine.process_milestone(mock_engine, node1)
 
     assert result == "processed_action"
+    assert mock_engine.remove_skip_requests == [2, 3]
     mock_engine.progress.add_milestone.assert_called_once_with(
         node1,
         milestone_engine.progress,

--- a/navigator_engine/tests/unit_tests/test_progress_tracker.py
+++ b/navigator_engine/tests/unit_tests/test_progress_tracker.py
@@ -21,13 +21,13 @@ def test_add_milestone(mock_tracker, mocker, completed):
     milestone_node = factories.NodeFactory(id=5, milestone=factories.MilestoneFactory())
     milestone_tracker = mocker.Mock(spec=ProgressTracker)
     milestone_tracker.route = milestone_route.copy()
-    milestone_tracker.entire_route = milestone_route.copy()
+    milestone_tracker.entire_route = route.copy() + milestone_route.copy()
     milestone_tracker.action_breadcrumbs = [
         {'actionID': 4, 'milestoneID': None},
         {'actionID': 5, 'milestoneID': None},
         {'actionID': 6, 'milestoneID': None}
     ]
-    milestone_tracker.skipped_actions = [3]
+    milestone_tracker.skipped_actions = [2, 3]
 
     ProgressTracker.add_milestone(mock_tracker, milestone_node, milestone_tracker, complete=completed)
 

--- a/navigator_engine/tests/util.py
+++ b/navigator_engine/tests/util.py
@@ -147,8 +147,9 @@ def create_demo_data():
             function="dict_value('1')"
         ), ref='tst-3-0-c'),  # id=17
         model.Node(action=model.Action(
-            title="Action 1",
-            html="Action 1 HTML"
+            title="Naomi Action 1",
+            html="Naomi Action 1 HTML",
+            skippable=False
         ), ref='tst-3-1-a'),  # id=18
         model.Node(action=model.Action(
             title="Complete",

--- a/navigator_engine/tests/util.py
+++ b/navigator_engine/tests/util.py
@@ -94,7 +94,7 @@ def create_demo_data():
     model.db.session.add(graph)
     model.db.session.commit()
 
-    graph_with_milestone = model.Graph(title="Demo Graph", version="0.1", description="Demo")
+    graph_with_milestones = model.Graph(title="Demo Graph", version="0.1", description="Demo")
     nodes = [
         model.Node(conditional=model.Conditional(
             title="Conditional 1",
@@ -105,6 +105,11 @@ def create_demo_data():
             data_loader="load_dict_value('data')",
             graph_id=1
         ), ref='tst-2-1-m'),  # id=12
+        model.Node(milestone=model.Milestone(
+            title="Naomi Data Review",
+            data_loader="load_dict_value('naomi')",
+            graph_id=3
+        ), ref='tst-2-6-m'),  # id=14
         model.Node(conditional=model.Conditional(
             title="Conditional 2",
             function="dict_value('2')"
@@ -117,21 +122,45 @@ def create_demo_data():
             title="Action 2",
             html="Action 2 HTML",
             resources=[model.Resource(title="Naomi", url="https://naomi.unaids.org")]
-        ), ref='tst-2-4-a'),  # id=14
+        ), ref='tst-2-4-a'),  # id=15
         model.Node(action=model.Action(
             title="Complete",
-            html="Action Complete",
+            html="Milestone Complete",
             complete=True
-        ), ref='tst-2-5-a'),  # id=15
+        ), ref='tst-2-5-a'),  # id=16
     ]
-    graph_with_milestone.edges = [
-        model.Edge(from_node=nodes[0], to_node=nodes[3], type=False),
+    graph_with_milestones.edges = [
+        model.Edge(from_node=nodes[0], to_node=nodes[4], type=False),
         model.Edge(from_node=nodes[0], to_node=nodes[1], type=True),
         model.Edge(from_node=nodes[1], to_node=nodes[2], type=True),
-        model.Edge(from_node=nodes[2], to_node=nodes[4], type=False),
-        model.Edge(from_node=nodes[2], to_node=nodes[5], type=True)
+        model.Edge(from_node=nodes[2], to_node=nodes[3], type=True),
+        model.Edge(from_node=nodes[3], to_node=nodes[5], type=False),
+        model.Edge(from_node=nodes[3], to_node=nodes[6], type=True)
     ]
-    model.db.session.add(graph_with_milestone)
+    model.db.session.add(graph_with_milestones)
+    model.db.session.commit()
+
+    graph_naomi = model.Graph(title="Naomi Data Review", version="0.1", description="Demo")
+    nodes = [
+        model.Node(conditional=model.Conditional(
+            title="Conditional 1",
+            function="dict_value('1')"
+        ), ref='tst-3-0-c'),  # id=17
+        model.Node(action=model.Action(
+            title="Action 1",
+            html="Action 1 HTML"
+        ), ref='tst-3-1-a'),  # id=18
+        model.Node(action=model.Action(
+            title="Complete",
+            html="Milestone Complete",
+            complete=True
+        ), ref='tst-3-2-a'),  # id=19
+    ]
+    graph_naomi.edges = [
+        model.Edge(from_node=nodes[0], to_node=nodes[1], type=False),
+        model.Edge(from_node=nodes[0], to_node=nodes[2], type=True)
+    ]
+    model.db.session.add(graph_naomi)
     model.db.session.commit()
 
 


### PR DESCRIPTION
This PR debugs problems with the skip logic. 
- Fixes a bug stopping you from checking if tasks had been skipped in a different milestone.
- Improves wording of the task shown to the user when Navigator realises they need to complete previous tasks.
- Adds an integration/ test for skip logic to check basic skip logic works. 
- In order to add the integration test, some changes had to be made to the test data meaning various other tests had to be updated. 

