### PR TITLE
NAV 212 Refactor graph analysis 

### DIFF
--- a/navigator_engine/common/network.py
+++ b/navigator_engine/common/network.py
@@ -53,6 +53,8 @@ class Network():
 
     def common_path(self, source):
         all_possible_paths = self.all_possible_paths(source)
+        if not all_possible_paths:
+            return []
         longest_path = max(all_possible_paths, key=len)
         nodes_common_to_all_paths = set.intersection(*map(set, all_possible_paths))
         common_path = list(filter(

--- a/navigator_engine/common/network.py
+++ b/navigator_engine/common/network.py
@@ -51,8 +51,8 @@ class Network():
             target=target
         ))
 
-    def common_path(self, source):
-        all_possible_paths = self.all_possible_paths(source)
+    def common_path(self, source=None, target=None):
+        all_possible_paths = self.all_possible_paths(source, target)
         if not all_possible_paths:
             return []
         longest_path = max(all_possible_paths, key=len)

--- a/navigator_engine/common/network.py
+++ b/navigator_engine/common/network.py
@@ -36,7 +36,7 @@ class Network():
             milestones = []
             for node in self.networkx.nodes():
                 if getattr(node, 'milestone_id'):
-                    milestones.append(node.milestone)
+                    milestones.append(node)
             self.milestones = milestones
         return self.milestones
 

--- a/navigator_engine/common/network.py
+++ b/navigator_engine/common/network.py
@@ -1,0 +1,67 @@
+import networkx
+from navigator_engine.common import DecisionError
+from navigator_engine import model
+
+
+class Network():
+
+    def __init__(self, networkx):
+        self.networkx = networkx
+        self.root_node = None
+        self.complete_node = None
+        self.milestones = None
+
+    def get_complete_node(self) -> model.Node:
+        if not self.complete_node:
+            for node in self.networkx.nodes():
+                if getattr(node, 'action') and node.action.complete:
+                    self.complete_node = node
+                    break
+            else:
+                raise DecisionError("Network has no complete node")
+        return self.complete_node
+
+    def get_root_node(self) -> model.Node:
+        if not self.root_node:
+            for node, in_degree in self.networkx.in_degree():
+                if in_degree == 0:
+                    self.root_node = node
+                    break
+            else:
+                raise DecisionError("Network has no root node")
+        return self.root_node
+
+    def get_milestones(self) -> None:
+        if not self.milestones:
+            milestones = []
+            for node in self.networkx.nodes():
+                if getattr(node, 'milestone_id'):
+                    milestones.append(node.milestone)
+            self.milestones = milestones
+        return self.milestones
+
+    def all_possible_paths(self, source=None, target=None):
+        if not target:
+            target = self.get_complete_node()
+        if not source:
+            source = self.get_root_node()
+        return list(networkx.all_simple_paths(
+            self.networkx,
+            source=source,
+            target=target
+        ))
+
+    def common_path(self, source):
+        all_possible_paths = self.all_possible_paths(source)
+        longest_path = max(all_possible_paths, key=len)
+        nodes_common_to_all_paths = set.intersection(*map(set, all_possible_paths))
+        common_path = list(filter(
+            lambda node: node in nodes_common_to_all_paths,
+            longest_path
+        ))
+        return common_path
+
+    def milestone_path(self, source):
+        common_path = self.common_path(source)[1:]
+        milestone_path = [node for node in common_path if getattr(node, 'milestone_id')]
+        return milestone_path

--- a/navigator_engine/common/network.py
+++ b/navigator_engine/common/network.py
@@ -31,7 +31,7 @@ class Network():
                 raise DecisionError("Network has no root node")
         return self.root_node
 
-    def get_milestones(self) -> None:
+    def get_milestones(self) -> list[model.Node]:
         if not self.milestones:
             milestones = []
             for node in self.networkx.nodes():
@@ -40,7 +40,8 @@ class Network():
             self.milestones = milestones
         return self.milestones
 
-    def all_possible_paths(self, source=None, target=None):
+    def all_possible_paths(self, source: model.Node = None,
+                           target: model.Node = None) -> list[list[model.Node]]:
         if not target:
             target = self.get_complete_node()
         if not source:
@@ -51,19 +52,21 @@ class Network():
             target=target
         ))
 
-    def common_path(self, source=None, target=None):
-        all_possible_paths = self.all_possible_paths(source, target)
-        if not all_possible_paths:
+    def common_path(self, source: model.Node = None,
+                    target: model.Node = None) -> list[model.Node]:
+        all_paths = self.all_possible_paths(source, target)
+        if not all_paths:
             return []
-        longest_path = max(all_possible_paths, key=len)
-        nodes_common_to_all_paths = set.intersection(*map(set, all_possible_paths))
+        longest_path = max(all_paths, key=len)
+        all_paths_as_sets = [set(path) for path in all_paths]
+        nodes_common_to_all_paths = set.intersection(*all_paths_as_sets)
         common_path = list(filter(
             lambda node: node in nodes_common_to_all_paths,
             longest_path
         ))
         return common_path
 
-    def milestone_path(self, source):
+    def milestone_path(self, source: model.Node) -> list[model.Node]:
         common_path = self.common_path(source)[1:]
         milestone_path = [node for node in common_path if getattr(node, 'milestone_id')]
         return milestone_path

--- a/navigator_engine/common/progress_tracker.py
+++ b/navigator_engine/common/progress_tracker.py
@@ -1,15 +1,14 @@
-from navigator_engine.common import DecisionError
+from navigator_engine.common.network import Network
 from typing import Any
 import navigator_engine.model as model
-import networkx
 import copy
 
 
 class ProgressTracker():
 
-    def __init__(self, network: networkx.DiGraph,
+    def __init__(self, network: Network,
                  route: list[model.Node] = [], skipped_actions: list[str] = []) -> None:
-        self.network: networkx.DiGraph = network
+        self.network = network
         self.previous_route: list[model.Node] = route.copy()
         self.entire_route: list[model.Node] = route.copy()
         self.route: list[model.Node] = []
@@ -17,8 +16,6 @@ class ProgressTracker():
         self.previously_skipped_actions: list[str] = skipped_actions.copy()
         self.skipped_actions: list[str] = skipped_actions.copy()
         self.action_breadcrumbs: list[dict[str, Any]] = []
-        self.complete_node: model.Node = self.get_complete_node()
-        self.root_node: model.Node = self.get_root_node()
         self.report: dict = {}
 
     def report_progress(self) -> dict:
@@ -28,18 +25,18 @@ class ProgressTracker():
             # Calculate percentage progress for current milestone
             milestones[-1]['progress'] = milestones[-1]['progress'].percentage_progress()
             current_milestone = milestones[-1]['id']
-        milestones_to_complete, milestone_list_is_complete = self.milestones_to_complete()
-        for node in milestones_to_complete:
+        for node in self.milestones_to_complete():
             milestones.append({
                 'id': node.ref,
                 'title': node.milestone.title,
                 'progress': 0,
                 'completed': False
             })
+        milestone_list_resolved = len(milestones) == len(self.network.get_milestones())
         self.report = {
             'progress': self.percentage_progress(),
             'currentMilestoneID': current_milestone,
-            'milestoneListFullyResolved': milestone_list_is_complete,
+            'milestoneListFullyResolved': milestone_list_resolved,
             'milestones': milestones
         }
         return self.report
@@ -88,7 +85,7 @@ class ProgressTracker():
             function = parent_node.conditional.function
             manual_confirmation = function.startswith("check_manual_confirmation")
 
-        for parent_node, child_node in self.network.out_edges(parent_node):
+        for parent_node, child_node in self.network.networkx.out_edges(parent_node):
             if (child_node != current_node
                     and getattr(child_node, 'action_id')
                     and not child_node.action.complete):
@@ -114,61 +111,23 @@ class ProgressTracker():
         self.action_breadcrumbs = self.action_breadcrumbs[:-1]
         return node_ref
 
-    def get_complete_node(self) -> model.Node:
-        for node in self.network.nodes():
-            if getattr(node, 'action') and node.action.complete:
-                return node
-        raise DecisionError("Network has no complete node")
-
-    def get_root_node(self) -> model.Node:
-        for node, in_degree in self.network.in_degree():
-            if in_degree == 0:
-                return node
-        raise DecisionError("Network has no root node")
-
-    def get_milestones(self) -> None:
-        for node in self.network.nodes():
-            if getattr(node, 'milestone_id'):
-                self.milestones.append(node.milestone)
-
     def percentage_progress(self) -> int:
         route = self.route.copy()
-        if getattr(self.route[-1], "action_id"):
-            if self.route[-1].action.complete:
+        if getattr(route[-1], "action_id"):
+            if route[-1].action.complete:
                 return 100
             route = route[:-1]  # If we're on an action don't count it
         current_node = route[-1]
         distance_travelled = len(route) - 1
-        all_possible_path_lengths = map(len, networkx.all_simple_paths(
-            self.network,
-            source=current_node,
-            target=self.complete_node
-        ))
-        longest_path_length = max(list(all_possible_path_lengths)) - 1
+        all_possible_paths = self.network.all_possible_paths(current_node)
+        longest_path_length = len(max(all_possible_paths, key=len)) - 1
         progress = distance_travelled / (longest_path_length + distance_travelled)
         percentage_progress = int(round(progress * 100))
         return percentage_progress
 
-    def milestones_to_complete(self) -> tuple[list[model.Node], bool]:
+    def milestones_to_complete(self):
         if getattr(self.route[-1], "action_id"):
             current_node = self.route[-2]
         else:
             current_node = self.route[-1]
-        all_possible_paths = networkx.all_simple_paths(
-            self.network,
-            source=current_node,
-            target=self.complete_node
-        )
-        milestone_paths = []
-        # Get all "milestone" paths
-        for path in all_possible_paths:
-            path = path[1:]  # Remove the current node
-            # Remove all nodes except milestones from each path
-            milestone_paths.append([node for node in path if getattr(node, 'milestone_id')])
-        # The first n elements that are the same in every milestone path consitute "known" milestones
-        milestones_to_complete = [x[0] for x in zip(*milestone_paths) if len(x) == x.count(x[0])]
-        # If all paths are equal, we know we have the complete list of remaining milestones
-        milestone_list_is_complete = False
-        if not milestone_paths or len(milestone_paths) == milestone_paths.count(milestone_paths[0]):
-            milestone_list_is_complete = True
-        return milestones_to_complete, milestone_list_is_complete
+        return self.network.milestone_path(current_node)

--- a/navigator_engine/tests/conftest.py
+++ b/navigator_engine/tests/conftest.py
@@ -59,6 +59,11 @@ def mock_engine():
 
 
 @pytest.fixture
+def mock_network():
+    return get_mock_network()
+
+
+@pytest.fixture
 def simple_network():
     return get_simple_network()
 

--- a/navigator_engine/tests/conftest.py
+++ b/navigator_engine/tests/conftest.py
@@ -5,6 +5,7 @@ from networkx import DiGraph
 import unittest.mock as mock
 from navigator_engine.common.progress_tracker import ProgressTracker
 from navigator_engine.common.decision_engine import DecisionEngine
+from navigator_engine.common.network import Network
 import navigator_engine.tests.factories as factories
 from navigator_engine.common.graph_loader import graph_loader, validate_graph
 import os
@@ -78,7 +79,7 @@ def test_production_client():
 def get_mock_engine():
     engine = mock.Mock(spec=DecisionEngine)
     engine.data = {}
-    engine.network = mock.Mock(spec=DiGraph)
+    engine.network = get_mock_network()
     engine.remove_skip_requests = []
     engine.skip_requests = []
     engine.progress = get_mock_tracker()
@@ -88,7 +89,7 @@ def get_mock_engine():
 
 def get_mock_tracker():
     tracker = mock.Mock(spec=ProgressTracker)
-    tracker.network = mock.Mock(spec=DiGraph)
+    tracker.network = get_mock_network()
     tracker.route = []
     tracker.entire_route = []
     tracker.previous_route = []
@@ -98,6 +99,15 @@ def get_mock_tracker():
     tracker.complete_node = factories.NodeFactory()
     tracker.action_breadcrumbs = []
     return tracker
+
+
+def get_mock_network():
+    network = mock.Mock(spec=Network)
+    network.milestones = None
+    network.root_node = None
+    network.complete_node = None
+    network.networkx = mock.Mock(spec=DiGraph)
+    return network
 
 
 def get_simple_network():

--- a/navigator_engine/tests/integration_tests/test_graph_loader.py
+++ b/navigator_engine/tests/integration_tests/test_graph_loader.py
@@ -37,7 +37,7 @@ class TestGraphLoader:
         edges = model.Edge.query.all()
         assert edges
 
-    def test_network_isomorphism(self):
+    def test_graph_isomorphism(self):
         graphs = model.Graph.query.all()
 
         with open(f'{app.config.get("DECISION_GRAPH_FOLDER")}/graph_test_data.p', 'rb') as test_data_file:

--- a/navigator_engine/tests/unit_tests/test_network.py
+++ b/navigator_engine/tests/unit_tests/test_network.py
@@ -76,3 +76,19 @@ def test_all_possible_paths(simple_network, source, target, expected_paths):
     )
     expected_paths = [[simple_network['nodes'][i] for i in nodes] for nodes in expected_paths]
     assert result == expected_paths
+
+
+@pytest.mark.parametrize("source, target, expected_result", [
+    (None, None, [1, 9, 12, 2, 8]),
+    (3, None, [3, 11, 4, 8]),
+    (None, 17, [1, 9, 12, 2, 10, 14, 16, 17]),
+    (9, 15, [9, 12, 2, 10, 14, 15])
+])
+def test_common_path(simple_network, source, target, expected_result):
+    network = Network(simple_network['network'])
+    result = network.common_path(
+        source=simple_network['nodes'].get(source),
+        target=simple_network['nodes'].get(target)
+    )
+    expected_result = [simple_network['nodes'][i] for i in expected_result]
+    assert result == expected_result

--- a/navigator_engine/tests/unit_tests/test_network.py
+++ b/navigator_engine/tests/unit_tests/test_network.py
@@ -48,8 +48,15 @@ def test_get_complete_node_raises_error(mock_network):
     (1, [9]),
     (3, [11])
 ])
-def test_milestone_path(mock_network, simple_network, current_node, expected_result):
+def test_milestone_path(simple_network, current_node, expected_result):
     network = Network(simple_network['network'])
     result = network.milestone_path(simple_network['nodes'][current_node])
     expected_milestones = [simple_network['nodes'][i] for i in expected_result]
     assert result == expected_milestones
+
+
+def test_get_milestones(simple_network):
+    network = Network(simple_network['network'])
+    result = network.get_milestones()
+    result_refs = {node.ref for node in result}
+    assert result_refs == {'tst-0-8-m', 'tst-0-9-m', 'tst-0-10-m'}

--- a/navigator_engine/tests/unit_tests/test_network.py
+++ b/navigator_engine/tests/unit_tests/test_network.py
@@ -60,3 +60,19 @@ def test_get_milestones(simple_network):
     result = network.get_milestones()
     result_refs = {node.ref for node in result}
     assert result_refs == {'tst-0-8-m', 'tst-0-9-m', 'tst-0-10-m'}
+
+
+@pytest.mark.parametrize("source, target, expected_paths", [
+    (None, None, [[1, 9, 12, 2, 3, 11, 4, 8], [1, 9, 12, 2, 10, 14, 16, 18, 8]]),
+    (3, None, [[3, 11, 4, 8]]),
+    (None, 17, [[1, 9, 12, 2, 10, 14, 16, 17]]),
+    (9, 15, [[9, 12, 2, 10, 14, 15]])
+])
+def test_all_possible_paths(simple_network, source, target, expected_paths):
+    network = Network(simple_network['network'])
+    result = network.all_possible_paths(
+        source=simple_network['nodes'].get(source),
+        target=simple_network['nodes'].get(target)
+    )
+    expected_paths = [[simple_network['nodes'][i] for i in nodes] for nodes in expected_paths]
+    assert result == expected_paths

--- a/navigator_engine/tests/unit_tests/test_network.py
+++ b/navigator_engine/tests/unit_tests/test_network.py
@@ -1,0 +1,55 @@
+from navigator_engine.common.network import Network
+import navigator_engine.tests.factories as factories
+from navigator_engine.common import DecisionError
+import networkx
+import pytest
+
+
+def test_get_root_node(mock_network):
+    nodes = [
+        factories.NodeFactory(conditional=factories.ConditionalFactory(id=1), conditional_id=1),
+        factories.NodeFactory(action=factories.ActionFactory(id=1), action_id=1),
+        factories.NodeFactory(action=factories.ActionFactory(id=2), action_id=2)
+    ]
+    mock_network.networkx = networkx.DiGraph()
+    mock_network.networkx.add_edges_from([
+        (nodes[0], nodes[1], {'type': True}),
+        (nodes[0], nodes[2], {'type': False})
+    ])
+    result = Network.get_root_node(mock_network)
+    assert result == nodes[0]
+
+
+def test_get_complete_node(mock_network):
+    nodes = [
+        factories.NodeFactory(id=2, action_id=1, action=factories.ActionFactory(id=1)),
+        factories.NodeFactory(id=3, action_id=2, action=factories.ActionFactory(id=2)),
+        factories.NodeFactory(id=4, action_id=3, action=factories.ActionFactory(id=3, complete=True))
+    ]
+    mock_network.networkx = networkx.DiGraph()
+    mock_network.networkx.add_nodes_from(nodes)
+    result = Network.get_complete_node(mock_network)
+    assert result == nodes[2]
+
+
+def test_get_complete_node_raises_error(mock_network):
+    nodes = [
+        factories.NodeFactory(id=2, action_id=1, action=factories.ActionFactory(id=1)),
+        factories.NodeFactory(id=3, action_id=2, action=factories.ActionFactory(id=2)),
+        factories.NodeFactory(id=4, action_id=3, action=factories.ActionFactory(id=3))
+    ]
+    mock_network.networkx = networkx.DiGraph()
+    mock_network.networkx.add_nodes_from(nodes)
+    with pytest.raises(DecisionError, match="has no complete node"):
+        Network.get_complete_node(mock_network)
+
+
+@pytest.mark.parametrize("current_node,expected_result", [
+    (1, [9]),
+    (3, [11])
+])
+def test_milestone_path(mock_network, simple_network, current_node, expected_result):
+    network = Network(simple_network['network'])
+    result = network.milestone_path(simple_network['nodes'][current_node])
+    expected_milestones = [simple_network['nodes'][i] for i in expected_result]
+    assert result == expected_milestones


### PR DESCRIPTION
This PR refactors the code to separate out graph analysis from progress tracking. 

This lays the ground work for projecting forwards into the decision tree.  The progress tracker module was getting too large and cumbersome and this seemed the most sensible refactor. 