### PR TITLE
NAV-57 Add unreached tasks to the action list

### DIFF
--- a/navigator_engine/api.py
+++ b/navigator_engine/api.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, jsonify, request, abort, Response
 from navigator_engine.common.decision_engine import DecisionEngine
-from navigator_engine.model import load_graph, Graph
+from navigator_engine.model import load_graph
 from navigator_engine.common import choose_graph, choose_data_loader
 from navigator_engine.common.action_list import create_action_list
 from navigator_engine import model

--- a/navigator_engine/api.py
+++ b/navigator_engine/api.py
@@ -104,7 +104,7 @@ def _get_engine(input_data: dict[str, Any]) -> DecisionEngine:
     if not input_data['data'].get('url'):
         abort(400, "No url to data specified in request")
 
-    graph: Graph = load_graph(choose_graph(input_data['data']['url']))
+    graph = load_graph(choose_graph(input_data['data']['url']))
     data_loader = choose_data_loader(input_data['data']['url'])
     source_data = input_data['data']
     skip_requests = input_data.get('skipActions', [])

--- a/navigator_engine/api.py
+++ b/navigator_engine/api.py
@@ -28,7 +28,7 @@ def decide() -> Response:
     """
 
     input_data = json.loads(request.data)
-    engine = _get_engine(input_data)
+    engine = _make_engine(input_data)
     engine.decide()
     del engine.decision['node']
     stop_action = input_data.get('actionID')
@@ -66,7 +66,7 @@ def decide_list() -> Response:
     """
     input_data = json.loads(request.data)
 
-    engine = _get_engine(input_data)
+    engine = _make_engine(input_data)
     action_list, path_fully_resolved = create_action_list(engine)
 
     return jsonify({
@@ -96,7 +96,7 @@ def action(action_id: str) -> Response:
     })
 
 
-def _get_engine(input_data: dict[str, Any]) -> DecisionEngine:
+def _make_engine(input_data: dict[str, Any]) -> DecisionEngine:
 
     if not input_data.get('data'):
         abort(400, "No data specified in request")

--- a/navigator_engine/api.py
+++ b/navigator_engine/api.py
@@ -1,7 +1,8 @@
 from flask import Blueprint, jsonify, request, abort
 from navigator_engine.common.decision_engine import DecisionEngine
 from navigator_engine.model import load_graph
-from navigator_engine.common import choose_graph, choose_data_loader, create_action_list
+from navigator_engine.common import choose_graph, choose_data_loader
+from navigator_engine.common.action_list import create_action_list
 from navigator_engine import model
 import json
 

--- a/navigator_engine/api.py
+++ b/navigator_engine/api.py
@@ -48,7 +48,7 @@ def decide():
 
 
 @api_blueprint.route('/decide/list', methods=['POST'])
-def action_list():
+def decide_list():
     """
     Get a list of actions that need to be completed.
 
@@ -66,11 +66,12 @@ def action_list():
     input_data = json.loads(request.data)
 
     engine = _get_engine(input_data)
+    action_list = create_action_list(engine)
 
     return jsonify({
         'milestones': engine.progress.report['milestones'],
         'progress': engine.progress.report['progress'],
-        'actionList': create_action_list(engine),
+        'actionList': action_list,
         'fullyResolved': False,
         'removeSkipActions': engine.remove_skip_requests,
     })

--- a/navigator_engine/api.py
+++ b/navigator_engine/api.py
@@ -66,13 +66,13 @@ def decide_list():
     input_data = json.loads(request.data)
 
     engine = _get_engine(input_data)
-    action_list = create_action_list(engine)
+    action_list, path_fully_resolved = create_action_list(engine)
 
     return jsonify({
         'milestones': engine.progress.report['milestones'],
         'progress': engine.progress.report['progress'],
         'actionList': action_list,
-        'fullyResolved': False,
+        'fullyResolved': path_fully_resolved,
         'removeSkipActions': engine.remove_skip_requests,
     })
 

--- a/navigator_engine/api.py
+++ b/navigator_engine/api.py
@@ -1,16 +1,17 @@
-from flask import Blueprint, jsonify, request, abort
+from flask import Blueprint, jsonify, request, abort, Response
 from navigator_engine.common.decision_engine import DecisionEngine
-from navigator_engine.model import load_graph
+from navigator_engine.model import load_graph, Graph
 from navigator_engine.common import choose_graph, choose_data_loader
 from navigator_engine.common.action_list import create_action_list
 from navigator_engine import model
+from typing import Any
 import json
 
 api_blueprint = Blueprint('main', __name__, url_prefix='/api/')
 
 
 @api_blueprint.route('/decide', methods=['POST'])
-def decide():
+def decide() -> Response:
     """
     Decide what needs to happen next for a given data file.
 
@@ -25,13 +26,13 @@ def decide():
         }
     ```
     """
+
     input_data = json.loads(request.data)
     engine = _get_engine(input_data)
     engine.decide()
-
     del engine.decision['node']
-
     stop_action = input_data.get('actionID')
+
     if stop_action and stop_action != engine.decision['id']:
         abort(
             400,
@@ -48,7 +49,7 @@ def decide():
 
 
 @api_blueprint.route('/decide/list', methods=['POST'])
-def decide_list():
+def decide_list() -> Response:
     """
     Get a list of actions that need to be completed.
 
@@ -78,13 +79,14 @@ def decide_list():
 
 
 @api_blueprint.route('/action/<action_id>')
-def action(action_id):
+def action(action_id: str) -> Response:
     """
     Get the details of a specific action in the task breadcrumbs.
     """
 
     node = model.load_node(node_ref=action_id)
     action = getattr(node, 'action', None)
+
     if not action:
         abort(400, f"Please specify a valid action ID. Action {action_id} not found.")
 
@@ -94,18 +96,19 @@ def action(action_id):
     })
 
 
-def _get_engine(input_data):
+def _get_engine(input_data: dict[str, Any]) -> DecisionEngine:
 
     if not input_data.get('data'):
         abort(400, "No data specified in request")
+
     if not input_data['data'].get('url'):
         abort(400, "No url to data specified in request")
 
-    graph = load_graph(choose_graph(input_data['data']['url']))
+    graph: Graph = load_graph(choose_graph(input_data['data']['url']))
     data_loader = choose_data_loader(input_data['data']['url'])
     source_data = input_data['data']
     skip_requests = input_data.get('skipActions', [])
-    stop_action = input_data.get('actionID')
+    stop_action = str(input_data.get('actionID'))
 
     return DecisionEngine(
         graph,

--- a/navigator_engine/common/__init__.py
+++ b/navigator_engine/common/__init__.py
@@ -1,11 +1,12 @@
 import ast
 from navigator_engine import model
-from navigator_common.progress_tracker import ProgressTracker
-from navigator_common.network import Network
-from navigator_common.decision_engine import DecisionEngine
+from navigator_engine.common.progress_tracker import ProgressTracker
+from navigator_engine.common.network import Network
+from navigator_engine.common.decision_engine import DecisionEngine
+from typing import Any, Callable
 
-CONDITIONAL_FUNCTIONS = {}
-DATA_LOADERS = {}
+CONDITIONAL_FUNCTIONS: dict[str, Callable] = {}
+DATA_LOADERS: dict[str, Callable] = {}
 
 
 def choose_graph(file_url):
@@ -55,7 +56,7 @@ def get_pluggable_function_and_args(function_string: str) -> tuple[str, tuple]:
     return function_name, eval_function_args
 
 
-def step_through_common_path(network, sources=[]):
+def step_through_common_path(network: Network, sources: list[model.Node] = []) -> ProgressTracker:
     source = None if not sources else sources.pop(0)
     progress = ProgressTracker(network)
     for node in network.common_path(source):
@@ -69,7 +70,7 @@ def step_through_common_path(network, sources=[]):
     return progress
 
 
-def create_action_list(engine: DecisionEngine):
+def create_action_list(engine: DecisionEngine) -> list[dict[str, Any]]:
     engine.decide()
 
     reached_actions = engine.progress.action_breadcrumbs

--- a/navigator_engine/common/__init__.py
+++ b/navigator_engine/common/__init__.py
@@ -1,9 +1,5 @@
 import ast
-from navigator_engine import model
-from navigator_engine.common.progress_tracker import ProgressTracker
-from navigator_engine.common.network import Network
-from navigator_engine.common.decision_engine import DecisionEngine
-from typing import Any, Callable
+from typing import Callable
 
 CONDITIONAL_FUNCTIONS: dict[str, Callable] = {}
 DATA_LOADERS: dict[str, Callable] = {}
@@ -54,44 +50,6 @@ def get_pluggable_function_and_args(function_string: str) -> tuple[str, tuple]:
     if type(eval_function_args) is not tuple:
         eval_function_args = (eval_function_args,)
     return function_name, eval_function_args
-
-
-def step_through_common_path(network: Network, sources: list[model.Node] = []) -> ProgressTracker:
-    source = None if not sources else sources.pop(0)
-    progress = ProgressTracker(network)
-    for node in network.common_path(source):
-        if getattr(node, 'milestone_id'):
-            milestone_graph = model.load_graph(node.milestone.graph_id)
-            milestone_network = Network(milestone_graph.to_networkx())
-            milestone_progress = step_through_common_path(milestone_network, sources)
-            progress.add_milestone(node, milestone_progress)
-        else:
-            progress.add_node(node)
-    return progress
-
-
-def create_action_list(engine: DecisionEngine) -> list[dict[str, Any]]:
-    engine.decide()
-
-    reached_actions = engine.progress.action_breadcrumbs
-    for action in reached_actions:
-        action['title'] = model.load_node(node_ref=action['id']).action.title
-        action['reached'] = True
-
-    ongoing_milestone_id = engine.progress.report.get('currentMilestoneID')
-    if ongoing_milestone_id:
-        ongoing_milestone_node = model.load_node(node_ref=ongoing_milestone_id)
-        sources = [ongoing_milestone_node, engine.decision['node']]
-    else:
-        sources = [engine.decision['node']]
-    progress = step_through_common_path(engine.network, sources=sources)
-
-    unreached_actions = progress.action_breadcrumbs
-    for action in unreached_actions:
-        action['title'] = model.load_node(node_ref=action['id']).action.title
-        action['reached'] = False
-
-    return reached_actions + unreached_actions
 
 
 class DecisionError(Exception):

--- a/navigator_engine/common/action_list.py
+++ b/navigator_engine/common/action_list.py
@@ -26,12 +26,15 @@ def create_action_list(engine: DecisionEngine) -> list[dict[str, Any]]:
         action['title'] = model.load_node(node_ref=action['id']).action.title
         action['reached'] = True
 
+    if engine.progress.entire_route[-1].action.complete:
+        return reached_actions
+
     ongoing_milestone_id = engine.progress.report.get('currentMilestoneID')
     if ongoing_milestone_id:
         ongoing_milestone_node = model.load_node(node_ref=ongoing_milestone_id)
-        sources = [ongoing_milestone_node, engine.route[-2]]
+        sources = [ongoing_milestone_node, engine.progress.entire_route[-2]]
     else:
-        sources = [engine.route[-2]]
+        sources = [engine.progress.entire_route[-2]]
     progress = step_through_common_path(engine.network, sources=sources)
 
     unreached_actions = progress.action_breadcrumbs[1:]

--- a/navigator_engine/common/action_list.py
+++ b/navigator_engine/common/action_list.py
@@ -8,14 +8,17 @@ from typing import Any
 def step_through_common_path(network: Network, sources: list[model.Node] = []) -> ProgressTracker:
     source = None if not sources else sources.pop(0)
     progress = ProgressTracker(network)
-    for node in network.common_path(source):
+    common_path, path_fully_resolved = network.common_path(source)
+    for node in common_path:
         progress.add_node(node)
         if getattr(node, 'milestone_id'):
             milestone_graph = model.load_graph(node.milestone.graph_id)
             milestone_network = Network(milestone_graph.to_networkx())
-            milestone_progress = step_through_common_path(milestone_network, sources)
+            milestone_progress, milestone_path_fully_resolved = step_through_common_path(milestone_network, sources)
+            if not milestone_path_fully_resolved:
+                path_fully_resolved = False
             progress.add_milestone(node, milestone_progress)
-    return progress
+    return progress, path_fully_resolved
 
 
 def create_action_list(engine: DecisionEngine) -> list[dict[str, Any]]:
@@ -35,11 +38,12 @@ def create_action_list(engine: DecisionEngine) -> list[dict[str, Any]]:
         sources = [ongoing_milestone_node, engine.progress.entire_route[-2]]
     else:
         sources = [engine.progress.entire_route[-2]]
-    progress = step_through_common_path(engine.network, sources=sources)
+    progress, path_fully_resolved = step_through_common_path(engine.network, sources=sources)
 
     unreached_actions = progress.action_breadcrumbs[1:]
     for action in unreached_actions:
         action['title'] = model.load_node(node_ref=action['id']).action.title
         action['reached'] = False
 
-    return reached_actions + unreached_actions
+    action_list = reached_actions + unreached_actions
+    return action_list, path_fully_resolved

--- a/navigator_engine/common/action_list.py
+++ b/navigator_engine/common/action_list.py
@@ -30,7 +30,7 @@ def create_action_list(engine: DecisionEngine) -> list[dict[str, Any]]:
         action['reached'] = True
 
     if engine.progress.entire_route[-1].action.complete:
-        return reached_actions
+        return reached_actions, True
 
     ongoing_milestone_id = engine.progress.report.get('currentMilestoneID')
     if ongoing_milestone_id:
@@ -46,4 +46,5 @@ def create_action_list(engine: DecisionEngine) -> list[dict[str, Any]]:
         action['reached'] = False
 
     action_list = reached_actions + unreached_actions
+
     return action_list, path_fully_resolved

--- a/navigator_engine/common/action_list.py
+++ b/navigator_engine/common/action_list.py
@@ -5,26 +5,33 @@ from navigator_engine.common.decision_engine import DecisionEngine
 from typing import Any
 
 
-def step_through_common_path(network: Network, sources: list[model.Node] = []) -> ProgressTracker:
+def step_through_common_path(network: Network,
+                             sources: list[model.Node] = []) -> tuple[ProgressTracker, bool]:
+
     source = None if not sources else sources.pop(0)
     progress = ProgressTracker(network)
     common_path, path_fully_resolved = network.common_path(source)
+
     for node in common_path:
         progress.add_node(node)
+
         if getattr(node, 'milestone_id'):
             milestone_graph = model.load_graph(node.milestone.graph_id)
             milestone_network = Network(milestone_graph.to_networkx())
             milestone_progress, milestone_path_fully_resolved = step_through_common_path(milestone_network, sources)
+            progress.add_milestone(node, milestone_progress)
+
             if not milestone_path_fully_resolved:
                 path_fully_resolved = False
-            progress.add_milestone(node, milestone_progress)
+
     return progress, path_fully_resolved
 
 
-def create_action_list(engine: DecisionEngine) -> list[dict[str, Any]]:
-    engine.decide()
+def create_action_list(engine: DecisionEngine) -> tuple[list[dict[str, Any]], bool]:
 
+    engine.decide()
     reached_actions = engine.progress.action_breadcrumbs
+
     for action in reached_actions:
         action['title'] = model.load_node(node_ref=action['id']).action.title
         action['reached'] = True
@@ -33,14 +40,17 @@ def create_action_list(engine: DecisionEngine) -> list[dict[str, Any]]:
         return reached_actions, True
 
     ongoing_milestone_id = engine.progress.report.get('currentMilestoneID')
+
     if ongoing_milestone_id:
         ongoing_milestone_node = model.load_node(node_ref=ongoing_milestone_id)
         sources = [ongoing_milestone_node, engine.progress.entire_route[-2]]
+
     else:
         sources = [engine.progress.entire_route[-2]]
-    progress, path_fully_resolved = step_through_common_path(engine.network, sources=sources)
 
+    progress, path_fully_resolved = step_through_common_path(engine.network, sources=sources)
     unreached_actions = progress.action_breadcrumbs[1:]
+
     for action in unreached_actions:
         action['title'] = model.load_node(node_ref=action['id']).action.title
         action['reached'] = False

--- a/navigator_engine/common/action_list.py
+++ b/navigator_engine/common/action_list.py
@@ -29,12 +29,12 @@ def create_action_list(engine: DecisionEngine) -> list[dict[str, Any]]:
     ongoing_milestone_id = engine.progress.report.get('currentMilestoneID')
     if ongoing_milestone_id:
         ongoing_milestone_node = model.load_node(node_ref=ongoing_milestone_id)
-        sources = [ongoing_milestone_node, engine.decision['node']]
+        sources = [ongoing_milestone_node, engine.route[-2]]
     else:
-        sources = [engine.decision['node']]
+        sources = [engine.route[-2]]
     progress = step_through_common_path(engine.network, sources=sources)
 
-    unreached_actions = progress.action_breadcrumbs
+    unreached_actions = progress.action_breadcrumbs[1:]
     for action in unreached_actions:
         action['title'] = model.load_node(node_ref=action['id']).action.title
         action['reached'] = False

--- a/navigator_engine/common/action_list.py
+++ b/navigator_engine/common/action_list.py
@@ -1,0 +1,43 @@
+from navigator_engine import model
+from navigator_engine.common.progress_tracker import ProgressTracker
+from navigator_engine.common.network import Network
+from navigator_engine.common.decision_engine import DecisionEngine
+from typing import Any
+
+
+def step_through_common_path(network: Network, sources: list[model.Node] = []) -> ProgressTracker:
+    source = None if not sources else sources.pop(0)
+    progress = ProgressTracker(network)
+    for node in network.common_path(source):
+        if getattr(node, 'milestone_id'):
+            milestone_graph = model.load_graph(node.milestone.graph_id)
+            milestone_network = Network(milestone_graph.to_networkx())
+            milestone_progress = step_through_common_path(milestone_network, sources)
+            progress.add_milestone(node, milestone_progress)
+        else:
+            progress.add_node(node)
+    return progress
+
+
+def create_action_list(engine: DecisionEngine) -> list[dict[str, Any]]:
+    engine.decide()
+
+    reached_actions = engine.progress.action_breadcrumbs
+    for action in reached_actions:
+        action['title'] = model.load_node(node_ref=action['id']).action.title
+        action['reached'] = True
+
+    ongoing_milestone_id = engine.progress.report.get('currentMilestoneID')
+    if ongoing_milestone_id:
+        ongoing_milestone_node = model.load_node(node_ref=ongoing_milestone_id)
+        sources = [ongoing_milestone_node, engine.decision['node']]
+    else:
+        sources = [engine.decision['node']]
+    progress = step_through_common_path(engine.network, sources=sources)
+
+    unreached_actions = progress.action_breadcrumbs
+    for action in unreached_actions:
+        action['title'] = model.load_node(node_ref=action['id']).action.title
+        action['reached'] = False
+
+    return reached_actions + unreached_actions

--- a/navigator_engine/common/action_list.py
+++ b/navigator_engine/common/action_list.py
@@ -9,13 +9,13 @@ def step_through_common_path(network: Network, sources: list[model.Node] = []) -
     source = None if not sources else sources.pop(0)
     progress = ProgressTracker(network)
     for node in network.common_path(source):
+        progress.add_node(node)
         if getattr(node, 'milestone_id'):
             milestone_graph = model.load_graph(node.milestone.graph_id)
             milestone_network = Network(milestone_graph.to_networkx())
             milestone_progress = step_through_common_path(milestone_network, sources)
-            progress.add_milestone(node, milestone_progress)
-        else:
-            progress.add_node(node)
+            complete = milestone_progress.route[-1].action.complete
+            progress.add_milestone(node, milestone_progress, complete)
     return progress
 
 

--- a/navigator_engine/common/action_list.py
+++ b/navigator_engine/common/action_list.py
@@ -18,7 +18,10 @@ def step_through_common_path(network: Network,
         if getattr(node, 'milestone_id'):
             milestone_graph = model.load_graph(node.milestone.graph_id)
             milestone_network = Network(milestone_graph.to_networkx())
-            milestone_progress, milestone_path_fully_resolved = step_through_common_path(milestone_network, sources)
+            milestone_progress, milestone_path_fully_resolved = step_through_common_path(
+                milestone_network,
+                sources
+            )
             progress.add_milestone(node, milestone_progress)
 
             if not milestone_path_fully_resolved:
@@ -48,7 +51,10 @@ def create_action_list(engine: DecisionEngine) -> tuple[list[dict[str, Any]], bo
     else:
         sources = [engine.progress.entire_route[-2]]
 
-    progress, path_fully_resolved = step_through_common_path(engine.network, sources=sources)
+    progress, path_fully_resolved = step_through_common_path(
+        engine.network,
+        sources=sources
+    )
     unreached_actions = progress.action_breadcrumbs[1:]
 
     for action in unreached_actions:

--- a/navigator_engine/common/action_list.py
+++ b/navigator_engine/common/action_list.py
@@ -14,8 +14,7 @@ def step_through_common_path(network: Network, sources: list[model.Node] = []) -
             milestone_graph = model.load_graph(node.milestone.graph_id)
             milestone_network = Network(milestone_graph.to_networkx())
             milestone_progress = step_through_common_path(milestone_network, sources)
-            complete = milestone_progress.route[-1].action.complete
-            progress.add_milestone(node, milestone_progress, complete)
+            progress.add_milestone(node, milestone_progress)
     return progress
 
 

--- a/navigator_engine/common/decision_engine.py
+++ b/navigator_engine/common/decision_engine.py
@@ -86,7 +86,7 @@ class DecisionEngine():
         milestone_result = milestone_engine.decide()
         self.remove_skip_requests += milestone_engine.remove_skip_requests
         if milestone_result['node'].action.complete:
-            self.progress.add_milestone(node, milestone_engine.progress, complete=True)
+            self.progress.add_milestone(node, milestone_engine.progress)
             next_node = self.get_next_node(node, True)
             return self.process_node(next_node)
         else:

--- a/navigator_engine/common/network.py
+++ b/navigator_engine/common/network.py
@@ -53,8 +53,9 @@ class Network():
         ))
 
     def common_path(self, source: model.Node = None,
-                    target: model.Node = None) -> list[model.Node]:
-        all_paths = self.all_possible_paths(source, target)
+                    target: model.Node = None, all_paths=None) -> list[model.Node]:
+        if not all_paths:
+            all_paths = self.all_possible_paths(source, target)
         if not all_paths:
             return [], True
         path_fully_resolved = len(all_paths) == 1
@@ -68,7 +69,9 @@ class Network():
         return common_path, path_fully_resolved
 
     def milestone_path(self, source: model.Node) -> list[model.Node]:
-        common_path, path_fully_resolved = self.common_path(source)
-        common_path = common_path[1:]
-        milestone_path = [node for node in common_path if getattr(node, 'milestone_id')]
-        return milestone_path, path_fully_resolved
+        milestone_paths = []
+        for path in self.all_possible_paths(source=source):
+            path = path[1:]
+            milestone_path = [node for node in path if getattr(node, 'milestone_id')]
+            milestone_paths.append(milestone_path)
+        return self.common_path(all_paths=milestone_paths)

--- a/navigator_engine/common/network.py
+++ b/navigator_engine/common/network.py
@@ -6,46 +6,65 @@ from navigator_engine import model
 class Network():
 
     def __init__(self, networkx):
+
         self.networkx = networkx
         self.root_node = None
         self.complete_node = None
         self.milestones = None
 
     def get_complete_node(self) -> model.Node:
+
         if not self.complete_node:
+
             for node in self.networkx.nodes():
+
                 if getattr(node, 'action') and node.action.complete:
                     self.complete_node = node
                     break
+
             else:
                 raise DecisionError("Network has no complete node")
+
         return self.complete_node
 
     def get_root_node(self) -> model.Node:
+
         if not self.root_node:
+
             for node, in_degree in self.networkx.in_degree():
+
                 if in_degree == 0:
                     self.root_node = node
                     break
+
             else:
                 raise DecisionError("Network has no root node")
+
         return self.root_node
 
     def get_milestones(self) -> list[model.Node]:
+
         if not self.milestones:
             milestones = []
+
             for node in self.networkx.nodes():
+
                 if getattr(node, 'milestone_id'):
                     milestones.append(node)
+
             self.milestones = milestones
+
         return self.milestones
 
     def all_possible_paths(self, source: model.Node = None,
                            target: model.Node = None) -> list[list[model.Node]]:
+
         if not target:
             target = self.get_complete_node()
+
         if not source:
             source = self.get_root_node()
+
         return list(networkx.all_simple_paths(
             self.networkx,
             source=source,
@@ -53,11 +72,14 @@ class Network():
         ))
 
     def common_path(self, source: model.Node = None,
-                    target: model.Node = None, all_paths=None) -> list[model.Node]:
+                    target: model.Node = None, all_paths=None) -> tuple[list[model.Node], bool]:
+
         if not all_paths:
             all_paths = self.all_possible_paths(source, target)
+
         if not all_paths:
             return [], True
+
         path_fully_resolved = len(all_paths) == 1
         longest_path = max(all_paths, key=len)
         all_paths_as_sets = [set(path) for path in all_paths]
@@ -66,12 +88,16 @@ class Network():
             lambda node: node in nodes_common_to_all_paths,
             longest_path
         ))
+
         return common_path, path_fully_resolved
 
-    def milestone_path(self, source: model.Node) -> list[model.Node]:
+    def milestone_path(self, source: model.Node) -> tuple[list[model.Node], bool]:
+
         milestone_paths = []
+
         for path in self.all_possible_paths(source=source):
             path = path[1:]
             milestone_path = [node for node in path if getattr(node, 'milestone_id')]
             milestone_paths.append(milestone_path)
+
         return self.common_path(all_paths=milestone_paths)

--- a/navigator_engine/common/network.py
+++ b/navigator_engine/common/network.py
@@ -56,7 +56,8 @@ class Network():
                     target: model.Node = None) -> list[model.Node]:
         all_paths = self.all_possible_paths(source, target)
         if not all_paths:
-            return []
+            return [], True
+        path_fully_resolved = len(all_paths) == 1
         longest_path = max(all_paths, key=len)
         all_paths_as_sets = [set(path) for path in all_paths]
         nodes_common_to_all_paths = set.intersection(*all_paths_as_sets)
@@ -64,9 +65,10 @@ class Network():
             lambda node: node in nodes_common_to_all_paths,
             longest_path
         ))
-        return common_path
+        return common_path, path_fully_resolved
 
     def milestone_path(self, source: model.Node) -> list[model.Node]:
-        common_path = self.common_path(source)[1:]
+        common_path, path_fully_resolved = self.common_path(source)
+        common_path = common_path[1:]
         milestone_path = [node for node in common_path if getattr(node, 'milestone_id')]
-        return milestone_path
+        return milestone_path, path_fully_resolved

--- a/navigator_engine/common/progress_tracker.py
+++ b/navigator_engine/common/progress_tracker.py
@@ -25,14 +25,14 @@ class ProgressTracker():
             # Calculate percentage progress for current milestone
             milestones[-1]['progress'] = milestones[-1]['progress'].percentage_progress()
             current_milestone = milestones[-1]['id']
-        for node in self.milestones_to_complete():
+        milestones_to_complete, milestone_list_resolved = self.milestones_to_complete()
+        for node in milestones_to_complete:
             milestones.append({
                 'id': node.ref,
                 'title': node.milestone.title,
                 'progress': 0,
                 'completed': False
             })
-        milestone_list_resolved = len(milestones) == len(self.network.get_milestones())
         self.report = {
             'progress': self.percentage_progress(),
             'currentMilestoneID': current_milestone,

--- a/navigator_engine/common/progress_tracker.py
+++ b/navigator_engine/common/progress_tracker.py
@@ -46,15 +46,15 @@ class ProgressTracker():
         self.route = []
         self.skipped_actions = self.previously_skipped_actions
 
-    def add_milestone(self, milestone_node: model.Node,
-                      milestone_progress, complete: bool = False) -> None:
+    def add_milestone(self, milestone_node: model.Node, milestone_progress) -> None:
         self.entire_route = milestone_progress.entire_route
         self.skipped_actions = milestone_progress.skipped_actions
+        milestone_complete = self.entire_route[-1].action.complete
         self.milestones.append({
             'id': milestone_node.ref,
             'title': milestone_node.milestone.title,
-            'progress': 100 if complete else milestone_progress,
-            'completed': complete
+            'progress': 100 if milestone_complete else milestone_progress,
+            'completed': milestone_complete
         })
 
         def add_milestone_id(breadcrumb):
@@ -65,7 +65,7 @@ class ProgressTracker():
             milestone_progress.action_breadcrumbs
         ))
 
-        if complete:
+        if milestone_complete:
             # Don't include the complete action in the action_breadcrumbs
             self.action_breadcrumbs.pop()
 

--- a/navigator_engine/tests/factories.py
+++ b/navigator_engine/tests/factories.py
@@ -33,6 +33,7 @@ class MilestoneFactory(factory.Factory):
     id: int = factory.Sequence(lambda n: int(n))
     title: str = "Test Milestone"
     data_loader: str = "return_empty()"
+    graph_id: int = 1
 
 
 class GraphFactory(factory.Factory):

--- a/navigator_engine/tests/integration_tests/test_endpoints.py
+++ b/navigator_engine/tests/integration_tests/test_endpoints.py
@@ -194,7 +194,7 @@ def setup_endpoint_test(mocker, data=None):
 
 
 @pytest.mark.usefixtures('with_app_context')
-def test_action_list(client, mocker):
+def test_decide_list_complete(client, mocker):
     data = {
         '1': True,
         '2': True,
@@ -279,6 +279,96 @@ def test_action_list(client, mocker):
             'completed': True,
             'id': 'tst-2-6-m',
             'progress': 100,
+            'title': 'Naomi Data Review'
+        }],
+    }
+
+
+@pytest.mark.usefixtures('with_app_context')
+def test_decide_list_incomplete(client, mocker):
+    data = {
+        '1': True,
+        '2': True,
+        'data': {'1': True, '2': False, '3': False, '4': True},
+        'naomi': {'1': True}
+    }
+    setup_endpoint_test(mocker, data)
+    response = client.post("/api/decide/list", data=json.dumps({
+        'data': {
+            'url': 'https://example.ckan/api/3/action/package_show?id=example',
+            'authorization_header': "example-api-key"
+        }
+    }))
+    assert response.json == {
+        'progress': 25,
+        'fullyResolved': False,
+        'removeSkipActions': [],
+        'actionList': [{
+            'id': 'tst-2-3-a',
+            'manualConfirmationRequired': False,
+            'milestoneID': None,
+            'reached': True,
+            'skipped': False,
+            'title': 'Action 1'
+        }, {
+            'id': 'tst-1-4-a',
+            'manualConfirmationRequired': False,
+            'milestoneID': 'tst-2-1-m',
+            'reached': True,
+            'skipped': False,
+            'title': 'Upload your geographic data'
+        }, {
+            'id': 'tst-1-5-a',
+            'manualConfirmationRequired': False,
+            'milestoneID': 'tst-2-1-m',
+            'reached': True,
+            'skipped': False,
+            'title': 'Validate your geographic data'
+        }, {
+            'id': 'tst-1-6-a',
+            'manualConfirmationRequired': False,
+            'milestoneID': 'tst-2-1-m',
+            'reached': False,
+            'skipped': False,
+            'title': 'Upload your survey data'
+        }, {
+            'id': 'tst-1-7-a',
+            'manualConfirmationRequired': False,
+            'milestoneID': 'tst-2-1-m',
+            'reached': False,
+            'skipped': False,
+            'title': 'Validate your survey data'
+        }, {
+            'id': 'tst-3-1-a',
+            'manualConfirmationRequired': False,
+            'milestoneID': 'tst-2-6-m',
+            'reached': False,
+            'skipped': False,
+            'title': 'Naomi Action 1'
+        }, {
+            'id': 'tst-2-4-a',
+            'manualConfirmationRequired': False,
+            'milestoneID': None,
+            'reached': False,
+            'skipped': False,
+            'title': 'Action 2'
+        }, {
+            'id': 'tst-2-5-a',
+            'manualConfirmationRequired': False,
+            'milestoneID': None,
+            'reached': False,
+            'skipped': False,
+            'title': 'Complete'
+        }],
+        'milestones': [{
+            'completed': False,
+            'id': 'tst-2-1-m',
+            'progress': 25,
+            'title': 'ADR Data'
+        }, {
+            'completed': False,
+            'id': 'tst-2-6-m',
+            'progress': 0,
             'title': 'Naomi Data Review'
         }],
     }

--- a/navigator_engine/tests/integration_tests/test_endpoints.py
+++ b/navigator_engine/tests/integration_tests/test_endpoints.py
@@ -211,7 +211,7 @@ def test_decide_list_complete(client, mocker):
     }))
     assert response.json == {
         'progress': 100,
-        'fullyResolved': False,
+        'fullyResolved': True,
         'removeSkipActions': ['tst-1-5-a'],
         'actionList': [{
             'id': 'tst-2-3-a',
@@ -301,7 +301,7 @@ def test_decide_list_incomplete(client, mocker):
     }))
     assert response.json == {
         'progress': 25,
-        'fullyResolved': False,
+        'fullyResolved': True,
         'removeSkipActions': [],
         'actionList': [{
             'id': 'tst-2-3-a',

--- a/navigator_engine/tests/unit_tests/test_action_list.py
+++ b/navigator_engine/tests/unit_tests/test_action_list.py
@@ -5,41 +5,51 @@ import networkx
 import pytest
 
 
-@pytest.mark.parametrize('sources, expected_breadcrumbs', [
+@pytest.mark.parametrize('sources, expected_result', [
     (
-        [],
-        [{'id': 'tst-0-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-         {'id': 'mini-2', 'milestoneID': 'tst-0-8-m', 'skipped': False, 'manualConfirmationRequired': False},
-         {'id': 'tst-0-12-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-         {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}]
+        [], (
+            [{'id': 'tst-0-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+             {'id': 'mini-2', 'milestoneID': 'tst-0-8-m', 'skipped': False, 'manualConfirmationRequired': False},
+             {'id': 'tst-0-12-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+             {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}],
+            False
+        )
     ),
     (
-        [12],
-        [{'id': 'tst-0-12-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-         {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}]
+        [12], (
+            [{'id': 'tst-0-12-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+             {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}],
+            False
+        )
     ),
     (
-        [14],
-        [{'id': 'tst-0-14-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-         {'id': 'tst-0-16-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-         {'id': 'tst-0-18-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-         {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}]
+        [14], (
+            [{'id': 'tst-0-14-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+             {'id': 'tst-0-16-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+             {'id': 'tst-0-18-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+             {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}],
+            True
+        )
     ),
     (
-        [3],
-        [{'id': 'tst-0-5-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-         {'id': 'mini-2', 'milestoneID': 'tst-0-10-m', 'skipped': False, 'manualConfirmationRequired': False},
-         {'id': 'tst-0-6-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-         {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}]
+        [3], (
+            [{'id': 'tst-0-5-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+             {'id': 'mini-2', 'milestoneID': 'tst-0-10-m', 'skipped': False, 'manualConfirmationRequired': False},
+             {'id': 'tst-0-6-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+             {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}],
+            True
+        )
     ),
     (
-        [9, 20],
-        [{'id': 'mini-2', 'milestoneID': 'tst-0-8-m', 'skipped': False, 'manualConfirmationRequired': False},
-         {'id': 'tst-0-12-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-         {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}]
+        [9, 20], (
+            [{'id': 'mini-2', 'milestoneID': 'tst-0-8-m', 'skipped': False, 'manualConfirmationRequired': False},
+             {'id': 'tst-0-12-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+             {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}],
+            False
+        )
     )
 ])
-def test_step_through_common_path(mocker, simple_network, sources, expected_breadcrumbs):
+def test_step_through_common_path(mocker, simple_network, sources, expected_result):
     mini_network = networkx.DiGraph()
     nodes = [
         factories.NodeFactory(id=20, conditional=factories.ConditionalFactory(id=1), conditional_id=1),
@@ -67,7 +77,8 @@ def test_step_through_common_path(mocker, simple_network, sources, expected_brea
     result = action_list.step_through_common_path(network, sources=sources)
 
     assert mock_load_graph.called_once_with(1)
-    assert result.action_breadcrumbs == expected_breadcrumbs
+    assert result[0].action_breadcrumbs == expected_result[0]
+    assert result[1] == expected_result[1]
 
 
 @pytest.mark.parametrize('milestone_id', [(None), ('milestone-id')])
@@ -100,7 +111,7 @@ def test_create_action_list(mock_engine, mock_tracker, mocker, milestone_id):
     )
     mock_step_through_common_path = mocker.patch(
         'navigator_engine.common.action_list.step_through_common_path',
-        return_value=mock_tracker
+        return_value=(mock_tracker, False)
     )
     result = action_list.create_action_list(mock_engine)
     expected_result = [{
@@ -142,4 +153,5 @@ def test_create_action_list(mock_engine, mock_tracker, mocker, milestone_id):
     )
     for breadcrumb in expected_result:
         mock_load_node.assert_any_call(node_ref=breadcrumb['id'])
-    assert result == expected_result
+    assert result[0] == expected_result
+    assert not result[1]

--- a/navigator_engine/tests/unit_tests/test_action_list.py
+++ b/navigator_engine/tests/unit_tests/test_action_list.py
@@ -78,7 +78,10 @@ def test_create_action_list(mock_engine, mock_tracker, mocker, milestone_id):
         {'id': 'tst-0-18-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
     ]
     mock_engine.progress.report = {'currentMilestoneID': milestone_id}
-    mock_engine.route = [factories.NodeFactory(), factories.NodeFactory()]
+    mock_engine.progress.entire_route = [
+        factories.NodeFactory(),
+        factories.NodeFactory(action=factories.ActionFactory())
+    ]
     mock_tracker.action_breadcrumbs = [
         {'id': 'tst-0-18-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
         {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}
@@ -129,9 +132,9 @@ def test_create_action_list(mock_engine, mock_tracker, mocker, milestone_id):
         'title': 'TST-0-7-A',
         'reached': False
     }]
-    expected_sources = [mock_engine.route[-2]]
+    expected_sources = [mock_engine.progress.entire_route[-2]]
     if milestone_id:
-        expected_sources = [milestone_node, mock_engine.route[-2]]
+        expected_sources = [milestone_node, mock_engine.progress.entire_route[-2]]
         mock_load_node.assert_any_call(node_ref=milestone_id)
     mock_step_through_common_path.assert_called_once_with(
         mock_engine.network,

--- a/navigator_engine/tests/unit_tests/test_action_list.py
+++ b/navigator_engine/tests/unit_tests/test_action_list.py
@@ -1,0 +1,70 @@
+import navigator_engine.common.action_list as action_list
+import navigator_engine.tests.factories as factories
+from navigator_engine.common.network import Network
+import networkx
+import pytest
+
+
+@pytest.mark.parametrize('sources, expected_breadcrumbs', [
+    (
+        [],
+        [{'id': 'tst-0-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+         {'id': 'mini-2', 'milestoneID': 'tst-0-8-m', 'skipped': False, 'manualConfirmationRequired': False},
+         {'id': 'tst-0-12-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+         {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}]
+    ),
+    (
+        [12],
+        [{'id': 'tst-0-12-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+         {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}]
+    ),
+    (
+        [14],
+        [{'id': 'tst-0-14-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+         {'id': 'tst-0-16-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+         {'id': 'tst-0-18-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+         {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}]
+    ),
+    (
+        [3],
+        [{'id': 'tst-0-5-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+         {'id': 'mini-2', 'milestoneID': 'tst-0-10-m', 'skipped': False, 'manualConfirmationRequired': False},
+         {'id': 'tst-0-6-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+         {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}]
+    ),
+    (
+        [9, 20],
+        [{'id': 'mini-2', 'milestoneID': 'tst-0-8-m', 'skipped': False, 'manualConfirmationRequired': False},
+         {'id': 'tst-0-12-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+         {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}]
+    )
+])
+def test_step_through_common_path(mocker, simple_network, sources, expected_breadcrumbs):
+    mini_network = networkx.DiGraph()
+    nodes = [
+        factories.NodeFactory(id=20, conditional=factories.ConditionalFactory(id=1), conditional_id=1),
+        factories.NodeFactory(id=21, action=factories.ActionFactory(id=1, complete=True), action_id=1, ref='mini-1'),
+        factories.NodeFactory(id=22, action=factories.ActionFactory(id=2), action_id=2, ref='mini-2')
+    ]
+    mini_network.add_edges_from([
+        (nodes[0], nodes[1], {'type': True}),
+        (nodes[0], nodes[2], {'type': False})
+    ])
+
+    mock_graph = mocker.Mock()
+    mock_graph.to_networkx.return_value = mini_network
+    mock_load_graph = mocker.patch(
+        'navigator_engine.common.action_list.model.load_graph',
+        return_value=mock_graph
+    )
+
+    all_nodes = simple_network['nodes']
+    for node in nodes:
+        all_nodes[node.id] = node
+
+    sources = [all_nodes[node_id] for node_id in sources]
+    network = Network(simple_network['network'])
+    result = action_list.step_through_common_path(network, sources=sources)
+
+    assert mock_load_graph.called_once_with(1)
+    assert result.action_breadcrumbs == expected_breadcrumbs

--- a/navigator_engine/tests/unit_tests/test_action_list.py
+++ b/navigator_engine/tests/unit_tests/test_action_list.py
@@ -50,6 +50,7 @@ import pytest
     )
 ])
 def test_step_through_common_path(mocker, simple_network, sources, expected_result):
+
     mini_network = networkx.DiGraph()
     nodes = [
         factories.NodeFactory(id=20, conditional=factories.ConditionalFactory(id=1), conditional_id=1),
@@ -69,6 +70,7 @@ def test_step_through_common_path(mocker, simple_network, sources, expected_resu
     )
 
     all_nodes = simple_network['nodes']
+
     for node in nodes:
         all_nodes[node.id] = node
 
@@ -83,6 +85,7 @@ def test_step_through_common_path(mocker, simple_network, sources, expected_resu
 
 @pytest.mark.parametrize('milestone_id', [(None), ('milestone-id')])
 def test_create_action_list(mock_engine, mock_tracker, mocker, milestone_id):
+
     mock_engine.progress.action_breadcrumbs = [
         {'id': 'tst-0-14-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
         {'id': 'tst-0-16-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
@@ -100,11 +103,14 @@ def test_create_action_list(mock_engine, mock_tracker, mocker, milestone_id):
     milestone_node = factories.NodeFactory(ref=milestone_id, milestone=factories.MilestoneFactory())
 
     def side_effect(node_ref=""):
+
         if node_ref == milestone_id:
             return milestone_node
+
         else:
             action = factories.ActionFactory(title=node_ref.upper())
             return factories.NodeFactory(action=action)
+
     mock_load_node = mocker.patch(
         'navigator_engine.common.action_list.model.load_node',
         side_effect=side_effect
@@ -144,14 +150,17 @@ def test_create_action_list(mock_engine, mock_tracker, mocker, milestone_id):
         'reached': False
     }]
     expected_sources = [mock_engine.progress.entire_route[-2]]
+
     if milestone_id:
         expected_sources = [milestone_node, mock_engine.progress.entire_route[-2]]
         mock_load_node.assert_any_call(node_ref=milestone_id)
+
+    for breadcrumb in expected_result:
+        mock_load_node.assert_any_call(node_ref=breadcrumb['id'])
+
     mock_step_through_common_path.assert_called_once_with(
         mock_engine.network,
         sources=expected_sources
     )
-    for breadcrumb in expected_result:
-        mock_load_node.assert_any_call(node_ref=breadcrumb['id'])
     assert result[0] == expected_result
     assert not result[1]

--- a/navigator_engine/tests/unit_tests/test_decision_engine.py
+++ b/navigator_engine/tests/unit_tests/test_decision_engine.py
@@ -196,8 +196,7 @@ def test_process_milestone_complete(mocker, mock_engine):
     assert mock_engine.remove_skip_requests == [2, 3]
     mock_engine.progress.add_milestone.assert_called_once_with(
         node1,
-        milestone_engine.progress,
-        complete=True
+        milestone_engine.progress
     )
     mock_engine.get_next_node.assert_called_once_with(node1, True)
     mock_engine.process_node.assert_called_once_with(node3)

--- a/navigator_engine/tests/unit_tests/test_network.py
+++ b/navigator_engine/tests/unit_tests/test_network.py
@@ -45,14 +45,15 @@ def test_get_complete_node_raises_error(mock_network):
 
 
 @pytest.mark.parametrize("current_node,expected_result", [
-    (1, [9]),
-    (3, [11])
+    (1, ([9], False)),
+    (3, ([11], True))
 ])
 def test_milestone_path(simple_network, current_node, expected_result):
     network = Network(simple_network['network'])
     result = network.milestone_path(simple_network['nodes'][current_node])
-    expected_milestones = [simple_network['nodes'][i] for i in expected_result]
-    assert result == expected_milestones
+    expected_milestones = [simple_network['nodes'][i] for i in expected_result[0]]
+    assert result[0] == expected_milestones
+    assert result[1] == expected_result[1]
 
 
 def test_get_milestones(simple_network):
@@ -79,10 +80,10 @@ def test_all_possible_paths(simple_network, source, target, expected_paths):
 
 
 @pytest.mark.parametrize("source, target, expected_result", [
-    (None, None, [1, 9, 12, 2, 8]),
-    (3, None, [3, 11, 4, 8]),
-    (None, 17, [1, 9, 12, 2, 10, 14, 16, 17]),
-    (9, 15, [9, 12, 2, 10, 14, 15])
+    (None, None, ([1, 9, 12, 2, 8], False)),
+    (3, None, ([3, 11, 4, 8], True)),
+    (None, 17, ([1, 9, 12, 2, 10, 14, 16, 17], True)),
+    (9, 15, ([9, 12, 2, 10, 14, 15], True))
 ])
 def test_common_path(simple_network, source, target, expected_result):
     network = Network(simple_network['network'])
@@ -90,5 +91,6 @@ def test_common_path(simple_network, source, target, expected_result):
         source=simple_network['nodes'].get(source),
         target=simple_network['nodes'].get(target)
     )
-    expected_result = [simple_network['nodes'][i] for i in expected_result]
-    assert result == expected_result
+    expected_path = [simple_network['nodes'][i] for i in expected_result[0]]
+    assert result[0] == expected_path
+    assert result[1] == expected_result[1]

--- a/navigator_engine/tests/unit_tests/test_progress_tracker.py
+++ b/navigator_engine/tests/unit_tests/test_progress_tracker.py
@@ -186,8 +186,7 @@ def test_report_progress(mocker, mock_tracker):
         {'id': '2-m', 'title': 'Mock', 'completed': False, 'progress': milestone_tracker}
     ]
     mock_tracker.percentage_progress.return_value = 50
-    mock_tracker.network.get_milestones.return_value = [..., ..., node]
-    mock_tracker.milestones_to_complete.return_value = [node]
+    mock_tracker.milestones_to_complete.return_value = [node], False
 
     result = ProgressTracker.report_progress(mock_tracker)
     assert result == {

--- a/navigator_engine/tests/unit_tests/test_progress_tracker.py
+++ b/navigator_engine/tests/unit_tests/test_progress_tracker.py
@@ -17,7 +17,8 @@ def test_add_milestone(mock_tracker, mocker, completed):
     ]
     mock_tracker.skipped_actions = [2]
 
-    milestone_route = [factories.NodeFactory(id=3), factories.NodeFactory(id=4)]
+    action = factories.ActionFactory(complete=completed)
+    milestone_route = [factories.NodeFactory(id=3), factories.NodeFactory(id=4, action=action)]
     milestone_node = factories.NodeFactory(id=5, milestone=factories.MilestoneFactory())
     milestone_tracker = mocker.Mock(spec=ProgressTracker)
     milestone_tracker.route = milestone_route.copy()
@@ -29,7 +30,7 @@ def test_add_milestone(mock_tracker, mocker, completed):
     ]
     milestone_tracker.skipped_actions = [2, 3]
 
-    ProgressTracker.add_milestone(mock_tracker, milestone_node, milestone_tracker, complete=completed)
+    ProgressTracker.add_milestone(mock_tracker, milestone_node, milestone_tracker)
 
     if completed:
         assert mock_tracker.action_breadcrumbs == [


### PR DESCRIPTION
This PR adds unreached tasks to the action list. 

Only actions that are on all paths between the current node and the complete node are added to the action list.  Optional actions are added if and when they are required by the BDG. 

Unreached actions do not include the current action. The current action is the last reached action in the list. 

Unreached actions are identified by the `"reached": False` param

Tagging @tomeksabala for optional review

![image](https://user-images.githubusercontent.com/8988344/145811912-5a4a9ade-6bbf-4957-9f8c-4e47b5f6e542.png)
