### PR TITLE
NAV 242 Unify breadcrumbs and action lists

### DIFF
--- a/navigator_engine/common/action_list.py
+++ b/navigator_engine/common/action_list.py
@@ -13,6 +13,7 @@ def step_through_common_path(network: Network,
     common_path, path_fully_resolved = network.common_path(source)
 
     for node in common_path:
+
         progress.add_node(node)
 
         if getattr(node, 'milestone_id'):
@@ -35,10 +36,6 @@ def create_action_list(engine: DecisionEngine) -> tuple[list[dict[str, Any]], bo
     engine.decide()
     reached_actions = engine.progress.action_breadcrumbs
 
-    for action in reached_actions:
-        action['title'] = model.load_node(node_ref=action['id']).action.title
-        action['reached'] = True
-
     if engine.progress.entire_route[-1].action.complete:
         return reached_actions, True
 
@@ -58,7 +55,6 @@ def create_action_list(engine: DecisionEngine) -> tuple[list[dict[str, Any]], bo
     unreached_actions = progress.action_breadcrumbs[1:]
 
     for action in unreached_actions:
-        action['title'] = model.load_node(node_ref=action['id']).action.title
         action['reached'] = False
 
     action_list = reached_actions + unreached_actions

--- a/navigator_engine/common/progress_tracker.py
+++ b/navigator_engine/common/progress_tracker.py
@@ -85,6 +85,7 @@ class ProgressTracker():
             function = parent_node.conditional.function
             manual_confirmation = function.startswith("check_manual_confirmation")
 
+        # If the current node is a conditional, add the child node that is an action
         for parent_node, child_node in self.network.networkx.out_edges(parent_node):
             if (child_node != current_node
                     and getattr(child_node, 'action_id')
@@ -93,15 +94,22 @@ class ProgressTracker():
                     'id': child_node.ref,
                     'milestoneID': None,  # Updated under self.add_milestone
                     'skipped': child_node.ref in self.skipped_actions,
-                    'manualConfirmationRequired': manual_confirmation
+                    'manualConfirmationRequired': manual_confirmation,
+                    'reached': True,
+                    'title': child_node.action.title,
+                    'terminus': child_node.action.complete
                 })
 
+        # If the current node is an action, add it to the breadcrumbs.
         if getattr(current_node, 'action_id'):
             self.action_breadcrumbs.append({
                 'id': current_node.ref,
                 'milestoneID': None,  # Updated under self.add_milestone
                 'skipped': False,
-                'manualConfirmationRequired': manual_confirmation
+                'manualConfirmationRequired': manual_confirmation,
+                'reached': True,
+                'terminus': current_node.action.complete,
+                'title': current_node.action.title
             })
 
     def pop_node(self) -> str:

--- a/navigator_engine/tests/factories.py
+++ b/navigator_engine/tests/factories.py
@@ -18,6 +18,7 @@ class ActionFactory(factory.Factory):
         model = models.Action
     id: int = factory.Sequence(lambda n: int(n))
     title: str = 'Test Action'
+    complete: bool = False
 
 
 class NodeFactory(factory.Factory):

--- a/navigator_engine/tests/integration_tests/test_endpoints.py
+++ b/navigator_engine/tests/integration_tests/test_endpoints.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 import navigator_engine.tests.util as test_util
+from unittest.mock import ANY
 """
 Endpoint tests use the client fixture, which requires the db, meaning they should
 be treated as integration tests.
@@ -41,14 +42,22 @@ def test_decide_complete(client, mocker):
             }
         },
         'actions': [
-            {'id': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-            {'id': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
-            {'id': 'tst-1-5-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
-            {'id': 'tst-1-6-a', 'milestoneID': 'tst-2-1-m', 'skipped': True, 'manualConfirmationRequired': False},
-            {'id': 'tst-1-7-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
-            {'id': 'tst-3-1-a', 'milestoneID': 'tst-2-6-m', 'skipped': False, 'manualConfirmationRequired': False},
-            {'id': 'tst-2-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-            {'id': 'tst-2-5-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}
+            {'id': 'tst-2-3-a', 'milestoneID': None, 'skipped': False,
+             'manualConfirmationRequired': False, 'reached': True, 'terminus': False, 'title': ANY},
+            {'id': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False,
+             'manualConfirmationRequired': False, 'reached': True, 'terminus': False, 'title': ANY},
+            {'id': 'tst-1-5-a', 'milestoneID': 'tst-2-1-m', 'skipped': False,
+             'manualConfirmationRequired': False, 'reached': True, 'terminus': False, 'title': ANY},
+            {'id': 'tst-1-6-a', 'milestoneID': 'tst-2-1-m', 'skipped': True,
+             'manualConfirmationRequired': False, 'reached': True, 'terminus': False, 'title': ANY},
+            {'id': 'tst-1-7-a', 'milestoneID': 'tst-2-1-m', 'skipped': False,
+             'manualConfirmationRequired': False, 'reached': True, 'terminus': False, 'title': ANY},
+            {'id': 'tst-3-1-a', 'milestoneID': 'tst-2-6-m', 'skipped': False,
+             'manualConfirmationRequired': False, 'reached': True, 'terminus': False, 'title': ANY},
+            {'id': 'tst-2-4-a', 'milestoneID': None, 'skipped': False,
+             'manualConfirmationRequired': False, 'reached': True, 'terminus': False, 'title': ANY},
+            {'id': 'tst-2-5-a', 'milestoneID': None, 'skipped': False,
+             'manualConfirmationRequired': False, 'reached': True, 'terminus': True, 'title': ANY}
         ],
         'removeSkipActions': ['tst-1-5-a'],
         'progress': {
@@ -80,10 +89,14 @@ def test_decide_incomplete(client, mocker):
     }))
     assert response.json == {
         'actions': [
-            {'id': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-            {'id': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
-            {'id': 'tst-1-5-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
-            {'id': 'tst-1-6-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False}
+            {'id': 'tst-2-3-a', 'milestoneID': None, 'skipped': False,
+             'manualConfirmationRequired': False, 'terminus': False, 'reached': True, 'title': ANY},
+            {'id': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False,
+             'manualConfirmationRequired': False, 'terminus': False, 'reached': True, 'title': ANY},
+            {'id': 'tst-1-5-a', 'milestoneID': 'tst-2-1-m', 'skipped': False,
+             'manualConfirmationRequired': False, 'terminus': False, 'reached': True, 'title': ANY},
+            {'id': 'tst-1-6-a', 'milestoneID': 'tst-2-1-m', 'skipped': False,
+             'manualConfirmationRequired': False, 'terminus': False, 'reached': True, 'title': ANY}
         ],
         'removeSkipActions': ['tst-1-5-a'],
         'decision': {
@@ -219,6 +232,7 @@ def test_decide_list_complete(client, mocker):
             'milestoneID': None,
             'reached': True,
             'skipped': False,
+            'terminus': False,
             'title': 'Action 1'
         }, {
             'id': 'tst-1-4-a',
@@ -226,6 +240,7 @@ def test_decide_list_complete(client, mocker):
             'milestoneID': 'tst-2-1-m',
             'reached': True,
             'skipped': False,
+            'terminus': False,
             'title': 'Upload your geographic data'
         }, {
             'id': 'tst-1-5-a',
@@ -233,6 +248,7 @@ def test_decide_list_complete(client, mocker):
             'milestoneID': 'tst-2-1-m',
             'reached': True,
             'skipped': False,
+            'terminus': False,
             'title': 'Validate your geographic data'
         }, {
             'id': 'tst-1-6-a',
@@ -240,6 +256,7 @@ def test_decide_list_complete(client, mocker):
             'milestoneID': 'tst-2-1-m',
             'reached': True,
             'skipped': True,
+            'terminus': False,
             'title': 'Upload your survey data'
         }, {
             'id': 'tst-1-7-a',
@@ -247,6 +264,7 @@ def test_decide_list_complete(client, mocker):
             'milestoneID': 'tst-2-1-m',
             'reached': True,
             'skipped': False,
+            'terminus': False,
             'title': 'Validate your survey data'
         }, {
             'id': 'tst-3-1-a',
@@ -254,6 +272,7 @@ def test_decide_list_complete(client, mocker):
             'milestoneID': 'tst-2-6-m',
             'reached': True,
             'skipped': False,
+            'terminus': False,
             'title': 'Naomi Action 1'
         }, {
             'id': 'tst-2-4-a',
@@ -261,6 +280,7 @@ def test_decide_list_complete(client, mocker):
             'milestoneID': None,
             'reached': True,
             'skipped': False,
+            'terminus': False,
             'title': 'Action 2'
         }, {
             'id': 'tst-2-5-a',
@@ -268,6 +288,7 @@ def test_decide_list_complete(client, mocker):
             'milestoneID': None,
             'reached': True,
             'skipped': False,
+            'terminus': True,
             'title': 'Complete'
         }],
         'milestones': [{
@@ -309,6 +330,7 @@ def test_decide_list_incomplete(client, mocker):
             'milestoneID': None,
             'reached': True,
             'skipped': False,
+            'terminus': False,
             'title': 'Action 1'
         }, {
             'id': 'tst-1-4-a',
@@ -316,6 +338,7 @@ def test_decide_list_incomplete(client, mocker):
             'milestoneID': 'tst-2-1-m',
             'reached': True,
             'skipped': False,
+            'terminus': False,
             'title': 'Upload your geographic data'
         }, {
             'id': 'tst-1-5-a',
@@ -323,6 +346,7 @@ def test_decide_list_incomplete(client, mocker):
             'milestoneID': 'tst-2-1-m',
             'reached': True,
             'skipped': False,
+            'terminus': False,
             'title': 'Validate your geographic data'
         }, {
             'id': 'tst-1-6-a',
@@ -330,6 +354,7 @@ def test_decide_list_incomplete(client, mocker):
             'milestoneID': 'tst-2-1-m',
             'reached': False,
             'skipped': False,
+            'terminus': False,
             'title': 'Upload your survey data'
         }, {
             'id': 'tst-1-7-a',
@@ -337,6 +362,7 @@ def test_decide_list_incomplete(client, mocker):
             'milestoneID': 'tst-2-1-m',
             'reached': False,
             'skipped': False,
+            'terminus': False,
             'title': 'Validate your survey data'
         }, {
             'id': 'tst-3-1-a',
@@ -344,6 +370,7 @@ def test_decide_list_incomplete(client, mocker):
             'milestoneID': 'tst-2-6-m',
             'reached': False,
             'skipped': False,
+            'terminus': False,
             'title': 'Naomi Action 1'
         }, {
             'id': 'tst-2-4-a',
@@ -351,6 +378,7 @@ def test_decide_list_incomplete(client, mocker):
             'milestoneID': None,
             'reached': False,
             'skipped': False,
+            'terminus': False,
             'title': 'Action 2'
         }, {
             'id': 'tst-2-5-a',
@@ -358,6 +386,7 @@ def test_decide_list_incomplete(client, mocker):
             'milestoneID': None,
             'reached': False,
             'skipped': False,
+            'terminus': True,
             'title': 'Complete'
         }],
         'milestones': [{

--- a/navigator_engine/tests/integration_tests/test_graph_processing.py
+++ b/navigator_engine/tests/integration_tests/test_graph_processing.py
@@ -2,6 +2,7 @@ import pytest
 import navigator_engine.model as model
 from navigator_engine.common.decision_engine import DecisionEngine
 import navigator_engine.tests.util as test_util
+from unittest.mock import ANY
 
 
 @pytest.mark.parametrize("data, expected_node_id", [
@@ -65,22 +66,36 @@ def test_graph_processing_with_milestones(data, expected_node_id):
 
 @pytest.mark.parametrize("data, expected_breadcrumbs", [
     ({'1': True, '2': True, 'data': {'1': True, '2': True, '3': False, '4': True}, 'naomi': {'1': True}},
-     [{'id': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-      {'id': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
-      {'id': 'tst-1-5-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
-      {'id': 'tst-1-6-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False}]),
+     [{'id': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+       'manualConfirmationRequired': False, 'terminus': False, 'title': ANY},
+      {'id': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'reached': True,
+       'manualConfirmationRequired': False, 'terminus': False, 'title': ANY},
+      {'id': 'tst-1-5-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'reached': True,
+       'manualConfirmationRequired': False, 'terminus': False, 'title': ANY},
+      {'id': 'tst-1-6-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'reached': True,
+       'manualConfirmationRequired': False, 'terminus': False, 'title': ANY}]),
     ({'1': True, '2': True, 'data': {'1': False, '2': True, '3': True, '4': True}, 'naomi': {'1': True}},
-     [{'id': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-      {'id': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False}]),
+     [{'id': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+      'manualConfirmationRequired': False, 'terminus': False, 'title': ANY},
+      {'id': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'reached': True,
+       'manualConfirmationRequired': False, 'terminus': False, 'title': ANY}]),
     ({'1': True, '2': True, 'data': {'1': True, '2': True, '3': True, '4': True}, 'naomi': {'1': True}},
-     [{'id': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-      {'id': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
-      {'id': 'tst-1-5-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
-      {'id': 'tst-1-6-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
-      {'id': 'tst-1-7-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'manualConfirmationRequired': False},
-      {'id': 'tst-3-1-a', 'milestoneID': 'tst-2-6-m', 'skipped': False, 'manualConfirmationRequired': False},
-      {'id': 'tst-2-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-      {'id': 'tst-2-5-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}])
+     [{'id': 'tst-2-3-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+       'manualConfirmationRequired': False, 'terminus': False, 'title': ANY},
+      {'id': 'tst-1-4-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'reached': True,
+       'manualConfirmationRequired': False, 'terminus': False, 'title': ANY},
+      {'id': 'tst-1-5-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'reached': True,
+       'manualConfirmationRequired': False, 'terminus': False, 'title': ANY},
+      {'id': 'tst-1-6-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'reached': True,
+       'manualConfirmationRequired': False, 'terminus': False, 'title': ANY},
+      {'id': 'tst-1-7-a', 'milestoneID': 'tst-2-1-m', 'skipped': False, 'reached': True,
+       'manualConfirmationRequired': False, 'terminus': False, 'title': ANY},
+      {'id': 'tst-3-1-a', 'milestoneID': 'tst-2-6-m', 'skipped': False, 'reached': True,
+       'manualConfirmationRequired': False, 'terminus': False, 'title': ANY},
+      {'id': 'tst-2-4-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+       'manualConfirmationRequired': False, 'terminus': False, 'title': ANY},
+      {'id': 'tst-2-5-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+       'manualConfirmationRequired': False, 'terminus': True, 'title': ANY}])
 ])
 @pytest.mark.usefixtures('with_app_context')
 def test_action_breadcrumbs(data, expected_breadcrumbs):
@@ -93,20 +108,32 @@ def test_action_breadcrumbs(data, expected_breadcrumbs):
 
 @pytest.mark.parametrize("data, skip, expected_breadcrumbs", [
     ({'1': True, '2': False, '3': False, '4': True}, ['tst-1-5-a'],
-     [{'id': 'tst-1-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-      {'id': 'tst-1-5-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
-      {'id': 'tst-1-6-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}]),
+     [{'id': 'tst-1-4-a', 'milestoneID': None, 'title': ANY, 'reached': True,
+      'terminus': False, 'skipped': False, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-5-a', 'milestoneID': None, 'title': ANY, 'reached': True,
+       'terminus': False, 'skipped': True, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-6-a', 'milestoneID': None, 'title': ANY, 'reached': True,
+       'terminus': False, 'skipped': False, 'manualConfirmationRequired': False}]),
     ({'1': True, '2': False, '3': False, '4': False}, ['tst-1-5-a', 'tst-1-6-a'],
-     [{'id': 'tst-1-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-      {'id': 'tst-1-5-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
-      {'id': 'tst-1-6-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
-      {'id': 'tst-1-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}]),
+     [{'id': 'tst-1-4-a', 'milestoneID': None, 'title': ANY, 'reached': True,
+      'terminus': False, 'skipped': False, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-5-a', 'milestoneID': None, 'title': ANY, 'reached': True,
+       'terminus': False, 'skipped': True, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-6-a', 'milestoneID': None, 'title': ANY, 'reached': True,
+       'terminus': False, 'skipped': True, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-7-a', 'milestoneID': None, 'title': ANY, 'reached': True,
+       'terminus': False, 'skipped': False, 'manualConfirmationRequired': False}]),
     ({'1': True, '2': False, '3': False, '4': False}, ['tst-1-5-a', 'tst-1-6-a', 'tst-1-7-a'],
-     [{'id': 'tst-1-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-      {'id': 'tst-1-5-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
-      {'id': 'tst-1-6-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
-      {'id': 'tst-1-7-a', 'milestoneID': None, 'skipped': True, 'manualConfirmationRequired': False},
-      {'id': 'tst-1-8-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}])
+     [{'id': 'tst-1-4-a', 'milestoneID': None, 'title': ANY, 'reached': True,
+      'terminus': False, 'skipped': False, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-5-a', 'milestoneID': None, 'title': ANY, 'reached': True,
+       'terminus': False, 'skipped': True, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-6-a', 'milestoneID': None, 'title': ANY, 'reached': True,
+       'terminus': False, 'skipped': True, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-7-a', 'milestoneID': None, 'title': ANY, 'reached': True,
+       'terminus': False, 'skipped': True, 'manualConfirmationRequired': False},
+      {'id': 'tst-1-8-a', 'milestoneID': None, 'title': ANY, 'reached': True,
+       'terminus': True, 'skipped': False, 'manualConfirmationRequired': False}])
 ])
 @pytest.mark.usefixtures('with_app_context')
 def test_action_breadcrumbs_with_skips(data, skip, expected_breadcrumbs):

--- a/navigator_engine/tests/unit_tests/test_action_list.py
+++ b/navigator_engine/tests/unit_tests/test_action_list.py
@@ -8,43 +8,60 @@ import pytest
 @pytest.mark.parametrize('sources, expected_result', [
     (
         [], (
-            [{'id': 'tst-0-4-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-             {'id': 'mini-2', 'milestoneID': 'tst-0-8-m', 'skipped': False, 'manualConfirmationRequired': False},
-             {'id': 'tst-0-12-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-             {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}],
+            [{'id': 'tst-0-4-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+              'manualConfirmationRequired': False, 'terminus': False, 'title': 'Test Action'},
+             {'id': 'mini-2', 'milestoneID': 'tst-0-8-m', 'skipped': False, 'reached': True,
+              'manualConfirmationRequired': False, 'terminus': False, 'title': 'Test Action'},
+             {'id': 'tst-0-12-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+              'manualConfirmationRequired': False, 'terminus': False, 'title': 'Test Action'},
+             {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+              'manualConfirmationRequired': False, 'terminus': True, 'title': 'Test Action'}],
             False
         )
     ),
     (
         [12], (
-            [{'id': 'tst-0-12-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-             {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}],
+            [{'id': 'tst-0-12-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+              'manualConfirmationRequired': False, 'terminus': False, 'title': 'Test Action'},
+             {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+              'manualConfirmationRequired': False, 'terminus': True, 'title': 'Test Action'}],
             False
         )
     ),
     (
         [14], (
-            [{'id': 'tst-0-14-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-             {'id': 'tst-0-16-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-             {'id': 'tst-0-18-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-             {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}],
+            [{'id': 'tst-0-14-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+              'manualConfirmationRequired': False, 'terminus': False, 'title': 'Test Action'},
+             {'id': 'tst-0-16-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+              'manualConfirmationRequired': False, 'terminus': False, 'title': 'Test Action'},
+             {'id': 'tst-0-18-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+              'manualConfirmationRequired': False, 'terminus': False, 'title': 'Test Action'},
+             {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+              'manualConfirmationRequired': False, 'terminus': True, 'title': 'Test Action'}],
             True
         )
     ),
     (
         [3], (
-            [{'id': 'tst-0-5-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-             {'id': 'mini-2', 'milestoneID': 'tst-0-10-m', 'skipped': False, 'manualConfirmationRequired': False},
-             {'id': 'tst-0-6-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-             {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}],
+            [{'id': 'tst-0-5-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+              'manualConfirmationRequired': False, 'terminus': False, 'title': 'Test Action'},
+             {'id': 'mini-2', 'milestoneID': 'tst-0-10-m', 'skipped': False, 'reached': True,
+              'manualConfirmationRequired': False, 'terminus': False, 'title': 'Test Action'},
+             {'id': 'tst-0-6-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+              'manualConfirmationRequired': False, 'terminus': False, 'title': 'Test Action'},
+             {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+              'manualConfirmationRequired': False, 'terminus': True, 'title': 'Test Action'}],
             True
         )
     ),
     (
         [9, 20], (
-            [{'id': 'mini-2', 'milestoneID': 'tst-0-8-m', 'skipped': False, 'manualConfirmationRequired': False},
-             {'id': 'tst-0-12-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-             {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}],
+            [{'id': 'mini-2', 'milestoneID': 'tst-0-8-m', 'skipped': False, 'reached': True,
+              'manualConfirmationRequired': False, 'terminus': False, 'title': 'Test Action'},
+             {'id': 'tst-0-12-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+              'manualConfirmationRequired': False, 'terminus': False, 'title': 'Test Action'},
+             {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+              'manualConfirmationRequired': False, 'terminus': True, 'title': 'Test Action'}],
             False
         )
     )
@@ -87,9 +104,12 @@ def test_step_through_common_path(mocker, simple_network, sources, expected_resu
 def test_create_action_list(mock_engine, mock_tracker, mocker, milestone_id):
 
     mock_engine.progress.action_breadcrumbs = [
-        {'id': 'tst-0-14-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-        {'id': 'tst-0-16-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-        {'id': 'tst-0-18-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
+        {'id': 'tst-0-14-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+         'manualConfirmationRequired': False, 'terminus': False, 'title': 'TST-0-14-A'},
+        {'id': 'tst-0-16-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+         'manualConfirmationRequired': False, 'terminus': False, 'title': 'TST-0-16-A'},
+        {'id': 'tst-0-18-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+         'manualConfirmationRequired': False, 'terminus': False, 'title': 'TST-0-18-A'},
     ]
     mock_engine.progress.report = {'currentMilestoneID': milestone_id}
     mock_engine.progress.entire_route = [
@@ -97,8 +117,10 @@ def test_create_action_list(mock_engine, mock_tracker, mocker, milestone_id):
         factories.NodeFactory(action=factories.ActionFactory())
     ]
     mock_tracker.action_breadcrumbs = [
-        {'id': 'tst-0-18-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False},
-        {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'manualConfirmationRequired': False}
+        {'id': 'tst-0-18-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+         'manualConfirmationRequired': False, 'terminus': False, 'title': 'TST-0-18-A'},
+        {'id': 'tst-0-7-a', 'milestoneID': None, 'skipped': False, 'reached': True,
+         'manualConfirmationRequired': False, 'terminus': True, 'title': 'TST-0-7-A'}
     ]
     milestone_node = factories.NodeFactory(ref=milestone_id, milestone=factories.MilestoneFactory())
 
@@ -126,37 +148,38 @@ def test_create_action_list(mock_engine, mock_tracker, mocker, milestone_id):
         'skipped': False,
         'manualConfirmationRequired': False,
         'title': 'TST-0-14-A',
-        'reached': True
+        'reached': True,
+        'terminus': False
     }, {
         'id': 'tst-0-16-a',
         'milestoneID': None,
         'skipped': False,
         'manualConfirmationRequired': False,
         'title': 'TST-0-16-A',
-        'reached': True
+        'reached': True,
+        'terminus': False
     }, {
         'id': 'tst-0-18-a',
         'milestoneID': None,
         'skipped': False,
         'manualConfirmationRequired': False,
         'title': 'TST-0-18-A',
-        'reached': True
+        'reached': True,
+        'terminus': False
     }, {
         'id': 'tst-0-7-a',
         'milestoneID': None,
         'skipped': False,
         'manualConfirmationRequired': False,
         'title': 'TST-0-7-A',
-        'reached': False
+        'reached': False,
+        'terminus': True
     }]
     expected_sources = [mock_engine.progress.entire_route[-2]]
 
     if milestone_id:
         expected_sources = [milestone_node, mock_engine.progress.entire_route[-2]]
         mock_load_node.assert_any_call(node_ref=milestone_id)
-
-    for breadcrumb in expected_result:
-        mock_load_node.assert_any_call(node_ref=breadcrumb['id'])
 
     mock_step_through_common_path.assert_called_once_with(
         mock_engine.network,

--- a/navigator_engine/tests/unit_tests/test_progress_tracker.py
+++ b/navigator_engine/tests/unit_tests/test_progress_tracker.py
@@ -152,8 +152,11 @@ def test_drop_action_breadcrumb(mock_tracker, function_name, manual):
     assert mock_tracker.action_breadcrumbs == [{
         'id': nodes[2].ref,
         'milestoneID': None,
+        'reached': True,
         'skipped': True,
-        'manualConfirmationRequired': manual
+        'terminus': False,
+        'manualConfirmationRequired': manual,
+        'title': 'Test Action'
     }]
 
 
@@ -174,7 +177,10 @@ def test_drop_action_breadcrumb_after_milestone(mock_tracker):
         'id': nodes[1].ref,
         'milestoneID': None,
         'skipped': False,
-        'manualConfirmationRequired': False
+        'manualConfirmationRequired': False,
+        'terminus': True,
+        'title': 'Test Action',
+        'reached': True
     }]
 
 


### PR DESCRIPTION
This PR ensures that the breadcrumbs given from `/decide` and the action lists provided at `/decide/list` have the same data structure.

```
{
    'id': <node id>, 
    'milestoneID': <current milestone id>,
    'skipped': <whether the action was skipped>,
    'reached': <whether the action has been reached>,
    'manualConfirmationRequired': <whether the action requires manual confirmation>,
    'terminus': <whether the action indicates the process has been completed>,
    'title': <the title of the action>
}
```

All relevant tests have been updated as well (the bigger part of the work). 